### PR TITLE
fix: watchtower镜像过旧

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -174,7 +174,7 @@ services:
       - outlook-net
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower:latest
     container_name: watchtower
     restart: unless-stopped
     volumes:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ services:
       - outlook-net
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower:latest
     container_name: watchtower
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - outlook-net
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower:latest
     container_name: watchtower
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above / 请在上方标题中提供更改的总体摘要 -->

## Pull request type / PR 类型

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. / 请尽量将 PR 限制为一种类型，如需要可提交多个 PR。 -->

Please check the type of change your PR introduces / 请勾选 PR 引入的更改类型:

- [√] Bugfix / Bug 修复
- [ ] Feature / 新功能
- [ ] Code style update (formatting, renaming) / 代码风格更新（格式化、重命名）
- [ ] Refactoring (no functional changes, no api changes) / 重构（无功能更改、无 API 更改）
- [ ] Build related changes / 构建相关更改
- [ ] Documentation content changes / 文档内容更改
- [ ] Other (please describe) / 其他（请描述）:

## What is the current behavior? / 当前行为是什么？

Issue [#65](https://github.com/ZeroPointSix/outlookEmailPlus/issues/65) 由于原版watchtower已archived，其硬编码的 API v1.25 在 Docker v29 已不被兼容，导致watchtower镜像在启动时会报错：
```
level=error msg="Error response from daemon: client version 1.25 is too old. Minimum supported API version is 1.40, please upgrade your client to a newer version"
```
从而无法正常启动

## What is the new behavior? / 新行为是什么？

切换到nicholas-fedor维护的fork

## Release notes / 发布日志

fix: watchtower镜像过旧