### PR TITLE
fix: add optional Watchtower Docker API override for Docker 29

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ GPTMAIL_API_KEY=gpt-test
 # 注意：若填写此处，docker-compose.yml 中 watchtower 服务会自动同步读取同一变量
 WATCHTOWER_HTTP_API_TOKEN=
 
-# Watchtower 连接 Docker Engine 使用的 Docker API 版本。
-# Docker 29+ 要求 >= 1.44；通常无需修改。
+# Watchtower Docker API 版本覆盖项。
+# 默认留空，让 Watchtower/Docker SDK 自动协商 API 版本。
+# 仅当 Docker 29.0-29.2 报 client version too old 时取消注释并设为 1.44。
 # WATCHTOWER_DOCKER_API_VERSION=1.44
 
 # Docker API 自更新（可选，高级功能）

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,10 @@ GPTMAIL_API_KEY=gpt-test
 # 注意：若填写此处，docker-compose.yml 中 watchtower 服务会自动同步读取同一变量
 WATCHTOWER_HTTP_API_TOKEN=
 
+# Watchtower 连接 Docker Engine 使用的 Docker API 版本。
+# Docker 29+ 要求 >= 1.44；通常无需修改。
+# WATCHTOWER_DOCKER_API_VERSION=1.44
+
 # Docker API 自更新（可选，高级功能）
 # ⚠️ 警告：启用后容器可通过 Docker API 控制宿主机其他容器，存在安全风险
 # 需同时取消 docker-compose.yml 中 docker.sock 挂载的注释

--- a/README.en.md
+++ b/README.en.md
@@ -183,6 +183,8 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_CLEANUP=true
+      # Docker 29+ requires client API >= 1.44; Watchtower's historical default is too low
+      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=false
     command: --http-api-update --label-enable
     labels:
@@ -209,12 +211,11 @@ Notes:
 3. Switch "Update Method" to "Docker API" in Settings
 4. ⚠️ Please fully understand the security implications before enabling
 
-> ⚠️ **Troubleshooting**: If you see `client version 1.25 is too old. Minimum supported API version is 1.44` in Watchtower logs, your local Watchtower image cache is stale (the embedded Docker client API is too old). Fix:
+> ⚠️ **Troubleshooting**: If you see `client version 1.25 is too old. Minimum supported API version is 1.44` in Watchtower logs, Docker Engine requires API 1.44+ but Watchtower's historical default API version is too low. The current `docker-compose.yml` sets `DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}`. Existing deployments can run:
 > ```bash
-> docker compose pull watchtower    # Pull the latest image
-> docker compose up -d watchtower   # Recreate the container
+> docker compose pull watchtower    # Pull the image
+> docker compose up -d watchtower   # Recreate with the new config
 > ```
-> The `docker-compose.yml` in this repo has pinned Watchtower to `1.7.1` to prevent this issue.
 
 #### ClawCloud / Reverse Proxy Deployment Notes
 
@@ -275,6 +276,8 @@ python -m unittest discover -s tests -v
   Watchtower API auth token. **Can be left empty** — both app and watchtower automatically use the same built-in default, making it work out of the box; for production, use a random strong password
 - `WATCHTOWER_API_URL`
   Watchtower API address, default `http://watchtower:8080` (Docker internal network, usually no need to change)
+- `WATCHTOWER_DOCKER_API_VERSION`
+  Docker API version Watchtower uses to connect to Docker Engine. Default: `1.44`; usually no need to change
 - `DOCKER_SELF_UPDATE_ALLOW`
   Whether to enable Docker API self-update, default `false`. ⚠️ Grants container Docker API access when enabled
 - `DOCKER_IMAGE`

--- a/README.en.md
+++ b/README.en.md
@@ -183,8 +183,9 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_CLEANUP=true
-      # Docker 29+ requires client API >= 1.44; Watchtower's historical default is too low
-      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}
+      # Optional: set WATCHTOWER_DOCKER_API_VERSION=1.44 in .env if Docker 29.0-29.2 reports client version too old
+      # Empty by default to keep Docker API negotiation and avoid forcing too-new API versions on older engines
+      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-}
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=false
     command: --http-api-update --label-enable
     labels:
@@ -211,11 +212,12 @@ Notes:
 3. Switch "Update Method" to "Docker API" in Settings
 4. ⚠️ Please fully understand the security implications before enabling
 
-> ⚠️ **Troubleshooting**: If you see `client version 1.25 is too old. Minimum supported API version is 1.44` in Watchtower logs, Docker Engine requires API 1.44+ but Watchtower's historical default API version is too low. The current `docker-compose.yml` sets `DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}`. Existing deployments can run:
+> ⚠️ **Troubleshooting**: If you see `client version 1.25 is too old. Minimum supported API version is 1.44` in Watchtower logs, Docker Engine requires a newer Docker API version than Watchtower's default client API. To avoid breaking older Docker Engines, `docker-compose.yml` keeps the override empty by default. Set `WATCHTOWER_DOCKER_API_VERSION=1.44` in `.env`, then run:
 > ```bash
 > docker compose pull watchtower    # Pull the image
 > docker compose up -d watchtower   # Recreate with the new config
 > ```
+> If you are still on Docker 24 or older, do not set this override, or set it to an API version supported by that engine.
 
 #### ClawCloud / Reverse Proxy Deployment Notes
 
@@ -277,7 +279,7 @@ python -m unittest discover -s tests -v
 - `WATCHTOWER_API_URL`
   Watchtower API address, default `http://watchtower:8080` (Docker internal network, usually no need to change)
 - `WATCHTOWER_DOCKER_API_VERSION`
-  Docker API version Watchtower uses to connect to Docker Engine. Default: `1.44`; usually no need to change
+  Optional Docker API version override for Watchtower. Default: empty, preserving API negotiation; set to `1.44` only if Docker 29.0-29.2 reports `client version too old`
 - `DOCKER_SELF_UPDATE_ALLOW`
   Whether to enable Docker API self-update, default `false`. ⚠️ Grants container Docker API access when enabled
 - `DOCKER_IMAGE`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ OutlookMail Plus 是一款面向个人与团队的注册邮箱管理器。
 - 当前模式固定面向个人 Microsoft 账号：Public Client、`tenant=consumers`、不支持 `client_secret`
 - Azure 应用注册的 **Supported account types** 应选择 **Accounts in any identity provider or organizational directory and personal Microsoft accounts**；仅组织目录会报 `unauthorized_client`，而 **Personal Microsoft accounts only** 会在写入前 `/common` 验证阶段报 `AADSTS9002331`
 - 如果 Azure 门户在切换 Supported account types 时提示 `Property api.requestedAccessTokenVersion is invalid`，请到 **Manifest** 中把 `api.requestedAccessTokenVersion` 改为 `2`
-- 如果已经开启 Public Client 仍然报"必须包含 `client_secret`"，说明当前回调仍被 Azure 视为机密 Web 客户端；此时应改用 **Mobile and desktop applications** 平台的 public redirect（如 `http://localhost`），并在工具里走手动粘贴回调 URL
+- 如果已经开启 Public Client仍然报"必须包含 `client_secret`"，说明当前回调仍被 Azure 视为机密 Web 客户端；此时应改用 **Mobile and desktop applications** 平台的 public redirect（如 `http://localhost`），并在工具里走手动粘贴回调 URL
 - 如果遇到 `AADSTS70000`（scope 未授权/失效），优先检查"授权时 scope"和"验证时 scope"是否一致，并重新执行一次 **强制 Consent** 授权
 - Graph 场景建议最小权限：**offline_access + Mail.Read + User.Read**；如需 IMAP 再额外补 **Office 365 Exchange Online → IMAP.AccessAsUser.All**
 - 支持 Graph / IMAP Scope 预设、错误引导、JWT audience/scope 诊断；前端默认推荐 **Graph 邮件预设**（后端环境变量 fallback 保持 IMAP 兼容 Scope）
@@ -188,6 +188,8 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_CLEANUP=true
+      # Docker 29+ 要求客户端 API >= 1.44；Watchtower 默认值偏低，需显式指定
+      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=false
     command: --http-api-update --label-enable
     labels:
@@ -214,12 +216,11 @@ networks:
 3. 在设置页选择"更新方式"为"Docker API"
 4. ⚠️ 请充分了解安全风险后再启用
 
-> ⚠️ **常见问题**：如果 Watchtower 容器日志中出现 `client version 1.25 is too old. Minimum supported API version is 1.44` 错误，说明你本地缓存了旧版 Watchtower 镜像（内嵌的 Docker 客户端 API 版本过旧）。解决方法：
+> ⚠️ **常见问题**：如果 Watchtower 容器日志中出现 `client version 1.25 is too old. Minimum supported API version is 1.44` 错误，说明当前 Docker Engine 要求 Docker API 1.44+，而 Watchtower 历史默认 API 版本偏低。当前 `docker-compose.yml` 已内置 `DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}`；已部署用户可执行：
 > ```bash
-> docker compose pull watchtower    # 拉取最新镜像
-> docker compose up -d watchtower   # 重建容器
+> docker compose pull watchtower    # 拉取镜像
+> docker compose up -d watchtower   # 用新配置重建容器
 > ```
-> 本项目 `docker-compose.yml` 已固定 Watchtower 版本为 `1.7.1`，可避免此类问题。
 
 #### ClawCloud / 反向代理部署注意事项
 
@@ -284,6 +285,8 @@ python -m unittest discover -s tests -v
   Watchtower API 鉴权令牌。**可留空**，留空时 app 和 watchtower 两边自动使用同一内置默认值，开箱即用；生产环境建议设置随机强密码
 - `WATCHTOWER_API_URL`
   Watchtower API 地址，默认 `http://watchtower:8080`（Docker 内部网络，通常无需修改）
+- `WATCHTOWER_DOCKER_API_VERSION`
+  Watchtower 连接 Docker Engine 时使用的 Docker API 版本，默认 `1.44`，通常无需修改
 - `DOCKER_SELF_UPDATE_ALLOW`
   是否启用 Docker API 自更新功能，默认 `false`。⚠️ 启用后容器可访问 Docker API，存在安全风险
 - `DOCKER_IMAGE`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ OutlookMail Plus 是一款面向个人与团队的注册邮箱管理器。
 - 当前模式固定面向个人 Microsoft 账号：Public Client、`tenant=consumers`、不支持 `client_secret`
 - Azure 应用注册的 **Supported account types** 应选择 **Accounts in any identity provider or organizational directory and personal Microsoft accounts**；仅组织目录会报 `unauthorized_client`，而 **Personal Microsoft accounts only** 会在写入前 `/common` 验证阶段报 `AADSTS9002331`
 - 如果 Azure 门户在切换 Supported account types 时提示 `Property api.requestedAccessTokenVersion is invalid`，请到 **Manifest** 中把 `api.requestedAccessTokenVersion` 改为 `2`
-- 如果已经开启 Public Client仍然报"必须包含 `client_secret`"，说明当前回调仍被 Azure 视为机密 Web 客户端；此时应改用 **Mobile and desktop applications** 平台的 public redirect（如 `http://localhost`），并在工具里走手动粘贴回调 URL
+- 如果已经开启 Public Client 仍然报"必须包含 `client_secret`"，说明当前回调仍被 Azure 视为机密 Web 客户端；此时应改用 **Mobile and desktop applications** 平台的 public redirect（如 `http://localhost`），并在工具里走手动粘贴回调 URL
 - 如果遇到 `AADSTS70000`（scope 未授权/失效），优先检查"授权时 scope"和"验证时 scope"是否一致，并重新执行一次 **强制 Consent** 授权
 - Graph 场景建议最小权限：**offline_access + Mail.Read + User.Read**；如需 IMAP 再额外补 **Office 365 Exchange Online → IMAP.AccessAsUser.All**
 - 支持 Graph / IMAP Scope 预设、错误引导、JWT audience/scope 诊断；前端默认推荐 **Graph 邮件预设**（后端环境变量 fallback 保持 IMAP 兼容 Scope）
@@ -188,8 +188,9 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_CLEANUP=true
-      # Docker 29+ 要求客户端 API >= 1.44；Watchtower 默认值偏低，需显式指定
-      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}
+      # 可选：Docker 29.0-29.2 若报 client version too old，可在 .env 设置 WATCHTOWER_DOCKER_API_VERSION=1.44
+      # 默认留空以保留 Docker API 自动协商，避免旧 Docker Engine 被强制使用过高 API 版本
+      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-}
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=false
     command: --http-api-update --label-enable
     labels:
@@ -216,11 +217,12 @@ networks:
 3. 在设置页选择"更新方式"为"Docker API"
 4. ⚠️ 请充分了解安全风险后再启用
 
-> ⚠️ **常见问题**：如果 Watchtower 容器日志中出现 `client version 1.25 is too old. Minimum supported API version is 1.44` 错误，说明当前 Docker Engine 要求 Docker API 1.44+，而 Watchtower 历史默认 API 版本偏低。当前 `docker-compose.yml` 已内置 `DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}`；已部署用户可执行：
+> ⚠️ **常见问题**：如果 Watchtower 容器日志中出现 `client version 1.25 is too old. Minimum supported API version is 1.44` 错误，说明当前 Docker Engine 要求更高的 Docker API 版本，而 Watchtower 的默认客户端 API 版本偏低。为避免影响旧版 Docker Engine，`docker-compose.yml` 默认保留自动协商；遇到该错误时可在 `.env` 中设置 `WATCHTOWER_DOCKER_API_VERSION=1.44`，然后执行：
 > ```bash
 > docker compose pull watchtower    # 拉取镜像
 > docker compose up -d watchtower   # 用新配置重建容器
 > ```
+> 如果仍使用 Docker 24 或更早版本，请不要设置此覆盖项，或设置为该 Docker Engine 支持的 API 版本。
 
 #### ClawCloud / 反向代理部署注意事项
 
@@ -286,7 +288,7 @@ python -m unittest discover -s tests -v
 - `WATCHTOWER_API_URL`
   Watchtower API 地址，默认 `http://watchtower:8080`（Docker 内部网络，通常无需修改）
 - `WATCHTOWER_DOCKER_API_VERSION`
-  Watchtower 连接 Docker Engine 时使用的 Docker API 版本，默认 `1.44`，通常无需修改
+  Watchtower Docker API 版本覆盖项。默认留空，保留 API 自动协商；仅当 Docker 29.0-29.2 出现 `client version too old` 时建议设为 `1.44`
 - `DOCKER_SELF_UPDATE_ALLOW`
   是否启用 Docker API 自更新功能，默认 `false`。⚠️ 启用后容器可访问 Docker API，存在安全风险
 - `DOCKER_IMAGE`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,9 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_CLEANUP=true
-      # Docker 29+ 要求客户端 API >= 1.44；Watchtower 默认值偏低，需显式指定
-      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}
+      # 可选：Docker 29.0-29.2 若报 client version too old，可在 .env 设置 WATCHTOWER_DOCKER_API_VERSION=1.44
+      # 默认留空以保留 Docker API 自动协商，避免旧 Docker Engine 被强制使用过高 API 版本
+      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-}
       # 禁用定时轮询，仅通过界面触发更新
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=false
     command: --http-api-update --label-enable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,8 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_CLEANUP=true
+      # Docker 29+ 要求客户端 API >= 1.44；Watchtower 默认值偏低，需显式指定
+      - DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}
       # 禁用定时轮询，仅通过界面触发更新
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=false
     command: --http-api-update --label-enable

--- a/tests/test_watchtower_compose_contract.py
+++ b/tests/test_watchtower_compose_contract.py
@@ -9,13 +9,22 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class WatchtowerComposeContractTests(unittest.TestCase):
-    def test_compose_sets_watchtower_docker_api_version_for_docker_29(self):
+    def test_compose_keeps_watchtower_docker_api_override_optional(self):
         content = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-        self.assertIn("DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}", content)
+        self.assertIn("DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-}", content)
+        self.assertNotIn("DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}", content)
+
+    def test_readme_snippets_keep_watchtower_docker_api_override_optional(self):
+        for path in ("README.md", "README.en.md"):
+            with self.subTest(path=path):
+                content = (REPO_ROOT / path).read_text(encoding="utf-8")
+                self.assertIn("DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-}", content)
+                self.assertNotIn("DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}", content)
 
     def test_env_example_documents_watchtower_docker_api_override(self):
         content = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
         self.assertIn("WATCHTOWER_DOCKER_API_VERSION=1.44", content)
+        self.assertIn("默认留空", content)
 
 
 if __name__ == "__main__":

--- a/tests/test_watchtower_compose_contract.py
+++ b/tests/test_watchtower_compose_contract.py
@@ -1,0 +1,22 @@
+"""Watchtower compose contract tests."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class WatchtowerComposeContractTests(unittest.TestCase):
+    def test_compose_sets_watchtower_docker_api_version_for_docker_29(self):
+        content = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+        self.assertIn("DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-1.44}", content)
+
+    def test_env_example_documents_watchtower_docker_api_override(self):
+        content = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+        self.assertIn("WATCHTOWER_DOCKER_API_VERSION=1.44", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wire `DOCKER_API_VERSION=${WATCHTOWER_DOCKER_API_VERSION:-}` into the bundled Watchtower service so Docker API overrides are available without disabling negotiation by default.
- Document `WATCHTOWER_DOCKER_API_VERSION=1.44` as an opt-in workaround for Docker 29.0-29.2 `client version ... too old` failures, with notes for older Docker Engine users to leave it unset or choose a supported API version.
- Add compose/README contract tests so the Watchtower override stays optional and does not regress back to a forced default API version.

## Context

Watchtower's historical Docker client API default can be lower than the Docker Engine 29.0-29.2 minimum, which can produce `client version 1.25 is too old. Minimum supported API version is 1.44` and make the app report that it cannot connect to `http://watchtower:8080`.

Docker's `DOCKER_API_VERSION` override disables API version negotiation when set to a non-empty value, so this PR now leaves the override empty by default and documents `WATCHTOWER_DOCKER_API_VERSION=1.44` as the targeted workaround for affected Docker 29 deployments.

Closes #79.

## Testing

- Not run locally: this workspace cannot clone or download the repository directly from GitHub (`CONNECT tunnel failed, response 403`). Verified the changed files through the GitHub connector and added/updated `tests/test_watchtower_compose_contract.py` for CI.
