### PR TITLE
[codex] fix issue 83 gunicorn concurrency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ WORKDIR /app
 # 设置环境变量
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    GUNICORN_WORKERS=1 \
+    GUNICORN_THREADS=8 \
+    GUNICORN_TIMEOUT=120
 
 # 复制依赖文件
 COPY requirements.txt .
@@ -21,7 +24,7 @@ RUN pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple && \
 COPY . .
 
 # 创建数据目录
-RUN mkdir -p /app/data
+RUN mkdir -p /app/data && chmod +x /app/scripts/start-gunicorn.sh
 
 # 暴露端口
 EXPOSE 5000
@@ -29,6 +32,6 @@ EXPOSE 5000
 # 健康检查
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s CMD ["python","-c","import urllib.request as u; u.urlopen('http://localhost:5000/healthz', timeout=4).read()"]
 
-# 启动应用（使用 Gunicorn，单 worker 避免 session 共享问题）
+# 启动应用：默认单 worker + 多线程，避免同步长轮询阻塞整站
 # 注意：禁用 --preload，避免在 master 进程中启动后台调度线程
-CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:5000", "--timeout", "120", "--access-logfile", "-", "web_outlook_app:app"]
+CMD ["scripts/start-gunicorn.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
       SECRET_KEY: "${SECRET_KEY:?请在 .env 中设置 SECRET_KEY（必须稳定，用于加密数据库敏感信息）}"
       # 一键更新 Token：与下方 watchtower 服务保持一致；留空将使用内置默认值，可直接工作
       WATCHTOWER_HTTP_API_TOKEN: "${WATCHTOWER_HTTP_API_TOKEN:-outlook-mail-plus-watchtower-default}"
+      # Gunicorn 并发：默认保持单 worker，使用多线程承载同步读信/等待接口，避免后台调度器重复启动
+      GUNICORN_WORKERS: "${GUNICORN_WORKERS:-1}"
+      GUNICORN_THREADS: "${GUNICORN_THREADS:-8}"
+      GUNICORN_TIMEOUT: "${GUNICORN_TIMEOUT:-120}"
       # OAuth Token 工具（可选；如需显式覆盖，可在 .env 中配置下列变量）
       # OAUTH_TOOL_ENABLED: "true"
       # OAUTH_CLIENT_ID: ""

--- a/registration-mail-pool-api.en.md
+++ b/registration-mail-pool-api.en.md
@@ -298,6 +298,7 @@ Behavior:
 
 - `mode=sync`: block until a new matching message is found, then return the message summary
 - `mode=async`: return `probe_id` and HTTP `202`
+- For high-concurrency or bulk registration flows, prefer `mode=async`; sync mode holds a request thread until a match or timeout
 
 ### `GET /api/external/probe/{probe_id}`
 

--- a/scripts/start-gunicorn.sh
+++ b/scripts/start-gunicorn.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+: "${GUNICORN_WORKERS:=1}"
+: "${GUNICORN_THREADS:=8}"
+: "${GUNICORN_TIMEOUT:=120}"
+: "${GUNICORN_BIND:=0.0.0.0:5000}"
+: "${GUNICORN_ACCESS_LOGFILE:=-}"
+
+require_positive_int() {
+  name="$1"
+  value="$2"
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "$name must be a positive integer, got: $value" >&2
+      exit 1
+      ;;
+  esac
+  if [ "$value" -lt 1 ]; then
+    echo "$name must be a positive integer, got: $value" >&2
+    exit 1
+  fi
+}
+
+require_positive_int GUNICORN_WORKERS "$GUNICORN_WORKERS"
+require_positive_int GUNICORN_THREADS "$GUNICORN_THREADS"
+require_positive_int GUNICORN_TIMEOUT "$GUNICORN_TIMEOUT"
+
+# Keep the default to one worker so the in-process scheduler is not duplicated.
+# Threads let sync endpoints such as wait-message share the worker instead of
+# blocking the entire site while waiting on upstream mail providers.
+exec gunicorn \
+  -w "$GUNICORN_WORKERS" \
+  --threads "$GUNICORN_THREADS" \
+  -b "$GUNICORN_BIND" \
+  --timeout "$GUNICORN_TIMEOUT" \
+  --access-logfile "$GUNICORN_ACCESS_LOGFILE" \
+  web_outlook_app:app

--- a/tests/test_gunicorn_startup_config.py
+++ b/tests/test_gunicorn_startup_config.py
@@ -1,0 +1,140 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+class GunicornStartupConfigTests(unittest.TestCase):
+    def _run_start_script_with_fake_gunicorn(self, extra_env=None):
+        script = REPO_ROOT / "scripts/start-gunicorn.sh"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            args_file = tmp / "gunicorn.args"
+            fake_gunicorn = tmp / "gunicorn"
+            fake_gunicorn.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"$@\" > \"$GUNICORN_ARGS_FILE\"\n",
+                encoding="utf-8",
+            )
+            fake_gunicorn.chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{tmp}:{env.get('PATH', '')}",
+                    "GUNICORN_ARGS_FILE": str(args_file),
+                }
+            )
+            if extra_env:
+                env.update(extra_env)
+            result = subprocess.run(
+                [str(script)],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            args = args_file.read_text(encoding="utf-8").splitlines() if args_file.exists() else []
+            return result, args
+
+    def test_dockerfile_uses_configurable_gunicorn_start_script(self):
+        dockerfile = _read("Dockerfile")
+
+        self.assertIn("GUNICORN_WORKERS=1", dockerfile)
+        self.assertIn("GUNICORN_THREADS=8", dockerfile)
+        self.assertIn("GUNICORN_TIMEOUT=120", dockerfile)
+        self.assertIn('CMD ["scripts/start-gunicorn.sh"]', dockerfile)
+        self.assertNotIn('CMD ["gunicorn", "-w", "1"', dockerfile)
+        self.assertIn("chmod +x /app/scripts/start-gunicorn.sh", dockerfile)
+
+    def test_compose_exposes_gunicorn_concurrency_knobs(self):
+        compose = _read("docker-compose.yml")
+
+        self.assertIn('GUNICORN_WORKERS: "${GUNICORN_WORKERS:-1}"', compose)
+        self.assertIn('GUNICORN_THREADS: "${GUNICORN_THREADS:-8}"', compose)
+        self.assertIn('GUNICORN_TIMEOUT: "${GUNICORN_TIMEOUT:-120}"', compose)
+
+    def test_start_script_keeps_single_worker_default_with_threads(self):
+        script = _read("scripts/start-gunicorn.sh")
+
+        self.assertIn(': "${GUNICORN_WORKERS:=1}"', script)
+        self.assertIn(': "${GUNICORN_THREADS:=8}"', script)
+        self.assertIn(': "${GUNICORN_TIMEOUT:=120}"', script)
+        self.assertIn("--threads", script)
+        self.assertIn("web_outlook_app:app", script)
+        self.assertNotIn("--preload", script)
+        self.assertIn("wait-message", script)
+
+    def test_start_script_passes_default_threaded_gunicorn_args(self):
+        result, args = self._run_start_script_with_fake_gunicorn()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            args,
+            [
+                "-w",
+                "1",
+                "--threads",
+                "8",
+                "-b",
+                "0.0.0.0:5000",
+                "--timeout",
+                "120",
+                "--access-logfile",
+                "-",
+                "web_outlook_app:app",
+            ],
+        )
+
+    def test_start_script_allows_env_overrides(self):
+        result, args = self._run_start_script_with_fake_gunicorn(
+            {
+                "GUNICORN_WORKERS": "2",
+                "GUNICORN_THREADS": "12",
+                "GUNICORN_TIMEOUT": "90",
+                "GUNICORN_BIND": "127.0.0.1:5050",
+                "GUNICORN_ACCESS_LOGFILE": "/tmp/access.log",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            args,
+            [
+                "-w",
+                "2",
+                "--threads",
+                "12",
+                "-b",
+                "127.0.0.1:5050",
+                "--timeout",
+                "90",
+                "--access-logfile",
+                "/tmp/access.log",
+                "web_outlook_app:app",
+            ],
+        )
+
+    def test_start_script_rejects_zero_or_non_numeric_values(self):
+        script = REPO_ROOT / "scripts/start-gunicorn.sh"
+        self.assertTrue(script.stat().st_mode & 0o111)
+
+        result, _args = self._run_start_script_with_fake_gunicorn({"GUNICORN_THREADS": "0"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("GUNICORN_THREADS must be a positive integer", result.stderr)
+
+        result, _args = self._run_start_script_with_fake_gunicorn({"GUNICORN_WORKERS": "many"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("GUNICORN_WORKERS must be a positive integer", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gunicorn_startup_config.py
+++ b/tests/test_gunicorn_startup_config.py
@@ -4,7 +4,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -20,8 +19,7 @@ class GunicornStartupConfigTests(unittest.TestCase):
             args_file = tmp / "gunicorn.args"
             fake_gunicorn = tmp / "gunicorn"
             fake_gunicorn.write_text(
-                "#!/bin/sh\n"
-                "printf '%s\\n' \"$@\" > \"$GUNICORN_ARGS_FILE\"\n",
+                "#!/bin/sh\n" 'printf \'%s\\n\' "$@" > "$GUNICORN_ARGS_FILE"\n',
                 encoding="utf-8",
             )
             fake_gunicorn.chmod(0o755)

--- a/注册与邮箱池接口文档.md
+++ b/注册与邮箱池接口文档.md
@@ -297,6 +297,7 @@ curl -X GET https://api.example.com/api/external/health \
 
 - `mode=sync`：阻塞等待，命中后直接返回邮件摘要
 - `mode=async`：返回 `probe_id`，HTTP 状态码为 `202`
+- 高并发/批量注册场景建议优先使用 `mode=async`，同步模式会占用一个请求线程直到命中或超时
 
 ### `GET /api/external/probe/{probe_id}`
 


### PR DESCRIPTION
## Summary

Fixes #83.

- Replaces the hard-coded single sync Gunicorn command with a configurable startup script.
- Keeps the default at one worker to avoid duplicating the in-process scheduler, but adds 8 threads so long-polling mail endpoints do not occupy the whole app.
- Exposes `GUNICORN_WORKERS`, `GUNICORN_THREADS`, and `GUNICORN_TIMEOUT` through Docker Compose.
- Documents that high-concurrency registration flows should prefer `mode=async` because sync wait mode holds a request thread until success or timeout.

## Root Cause

The v2.7.0 container started Gunicorn with a single sync worker and no threads. Endpoints such as `/api/external/wait-message` can block while polling upstream mail providers, so one long request could block the only worker and make other UI/API requests appear stuck or time out.

## Validation

- `sh -n scripts/start-gunicorn.sh`
- `python3 -m unittest tests.test_gunicorn_startup_config -v` passed, 6 tests.
- `CI=true python -m unittest discover -s tests -v` passed, 1540 tests, 13 skipped.
- Also ran `python3 -m unittest discover -s tests -v` without `CI=true`; it ran 1540 tests and failed only the 4 real CF Worker E2E tests because the upstream CF Worker returned HTTP 400 (`UPSTREAM_BAD_PAYLOAD`). The test file intentionally skips these real-upstream tests in CI due upstream instability, so this is recorded as external dependency noise rather than caused by this Gunicorn change.