### PR TITLE
Fix OAuth token save validation scope mismatch

### DIFF
--- a/outlook_web/controllers/token_tool.py
+++ b/outlook_web/controllers/token_tool.py
@@ -215,8 +215,9 @@ def save_to_account() -> Any:
     if compatibility_error:
         return build_error_response("OAUTH_CONFIG_INVALID", compatibility_error, status=400)
 
-    validation_scope = (data.get("scope") or "").strip() or COMPATIBLE_SCOPE
-    if validation_scope == LEGACY_GRAPH_SCOPE:
+    explicit_scope = (data.get("scope") or data.get("requested_scope") or data.get("granted_scope") or "").strip()
+    validation_scope = explicit_scope or COMPATIBLE_SCOPE
+    if not explicit_scope and validation_scope == LEGACY_GRAPH_SCOPE:
         validation_scope = COMPATIBLE_SCOPE
 
     valid, error_msg, new_rt = graph_service.test_refresh_token_with_rotation(

--- a/static/js/features/token_tool.js
+++ b/static/js/features/token_tool.js
@@ -434,6 +434,7 @@ async function confirmSaveToAccount() {
         mode,
         refresh_token: resultData.refresh_token,
         client_id: resultData.client_id,
+        scope: resultData.requested_scope || resultData.granted_scope || '',
     };
 
     if (mode === 'update') {

--- a/tests/test_oauth_tool.py
+++ b/tests/test_oauth_tool.py
@@ -898,7 +898,31 @@ class OAuthToolApiSaveTests(OAuthToolTestBase):
         )
 
     @patch("outlook_web.services.graph.test_refresh_token_with_rotation")
-    def test_save_maps_legacy_graph_scope_to_imap_validation_scope(self, mock_test_rt):
+    def test_save_uses_explicit_token_scope_for_validation(self, mock_test_rt):
+        mock_test_rt.return_value = (True, None, None)
+        with self.app.test_client() as client:
+            self._login(client)
+            resp = client.post(
+                "/api/token-tool/save",
+                json={
+                    "mode": "create",
+                    "email": "explicit-scope@oauth-test.com",
+                    "client_id": "new-cid",
+                    "refresh_token": "new-rt",
+                    "scope": "Mail.Read User.Read offline_access openid profile",
+                },
+            )
+            self.assertEqual(resp.status_code, 200)
+
+        _args, kwargs = mock_test_rt.call_args
+        self.assertEqual(kwargs.get("tenant"), "consumers")
+        self.assertEqual(
+            kwargs.get("scope"),
+            "Mail.Read User.Read offline_access openid profile",
+        )
+
+    @patch("outlook_web.services.graph.test_refresh_token_with_rotation")
+    def test_save_preserves_explicit_graph_default_scope_for_validation(self, mock_test_rt):
         mock_test_rt.return_value = (True, None, None)
         with self.app.test_client() as client:
             self._login(client)
@@ -918,7 +942,7 @@ class OAuthToolApiSaveTests(OAuthToolTestBase):
         self.assertEqual(kwargs.get("tenant"), "consumers")
         self.assertEqual(
             kwargs.get("scope"),
-            "offline_access https://outlook.office.com/IMAP.AccessAsUser.All",
+            "offline_access https://graph.microsoft.com/.default",
         )
 
     @patch("outlook_web.services.graph.test_refresh_token_with_rotation")


### PR DESCRIPTION
## Summary

Fixes OAuth Token 工具写入账号时的 refresh token 校验 scope 不一致问题。

当用户使用 Graph 命名权限（如 `Mail.Read User.Read offline_access`）完成授权后，工具可以拿到 token，但写入账号前的后端校验会回退到默认兼容 scope，导致 Microsoft 返回 `AADSTS70000`。

本次修改让 Token 工具在保存账号时透传本次授权 scope，后端优先使用显式 scope 校验 refresh token；旧链路未传 scope 时仍保留原默认兼容逻辑。

## Changes

- `static/js/features/token_tool.js`
  - 保存账号时增加 `scope` 字段
  - 来源优先级：`requested_scope` -> `granted_scope`

- `outlook_web/controllers/token_tool.py`
  - `save_to_account` 优先使用显式 scope 校验 token
  - 仅在未传显式 scope 时保留旧的 legacy scope 映射行为

- `tests/test_oauth_tool.py`
  - 增加显式 scope 校验路径覆盖
  - 调整显式 Graph scope 的期望，避免被错误映射到 IMAP scope

## Testing

Not run per request.

Fixes ZeroPointSix/outlookEmailPlus#107
