### PR TITLE
fix(verification): unify compact extraction path for ZER-90

### DIFF
--- a/outlook_web/routes/emails.py
+++ b/outlook_web/routes/emails.py
@@ -22,6 +22,11 @@ def create_blueprint() -> Blueprint:
         methods=["GET"],
     )
     bp.add_url_rule(
+        "/api/emails/<email_addr>/verification",
+        view_func=emails_controller.api_extract_verification,
+        methods=["GET"],
+    )
+    bp.add_url_rule(
         "/api/emails/<email_addr>/extract-verification",
         view_func=emails_controller.api_extract_verification,
         methods=["GET"],

--- a/outlook_web/services/account_compact_summary.py
+++ b/outlook_web/services/account_compact_summary.py
@@ -92,7 +92,9 @@ def _resolve_account_verification_policy(account_id: int) -> Dict[str, Any]:
         return {"code_length": "6-6", "code_regex": None}
 
 
-def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]], *, policy: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, str]]:
+def _pick_latest_verification_message(
+    messages: Iterable[Dict[str, Any]], *, policy: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, str]]:
     latest_match: Optional[Dict[str, str]] = None
 
     for message in messages:

--- a/outlook_web/services/account_compact_summary.py
+++ b/outlook_web/services/account_compact_summary.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional
 
 from outlook_web.repositories import accounts as accounts_repo
-from outlook_web.services.verification_extractor import extract_verification_info
+from outlook_web.services.verification_extractor import apply_confidence_gate, extract_verification_info_with_options
 
 COMPACT_SUMMARY_FIELDS = (
     "latest_email_subject",
@@ -90,11 +90,13 @@ def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]]) -> Opt
 
         candidate_payload = {
             "subject": str(message.get("subject") or ""),
+            "body": str(message.get("body_preview") or ""),
             "body_preview": str(message.get("body_preview") or ""),
         }
 
         try:
-            result = extract_verification_info(candidate_payload)
+            result = extract_verification_info_with_options(candidate_payload, code_source="all", code_length="6-6")
+            result = apply_confidence_gate(result, enforce_mutual_exclusion=False)
         except ValueError:
             continue
 

--- a/outlook_web/services/account_compact_summary.py
+++ b/outlook_web/services/account_compact_summary.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional
 
 from outlook_web.repositories import accounts as accounts_repo
+from outlook_web.repositories import groups as groups_repo
 from outlook_web.services.verification_extractor import apply_confidence_gate, extract_verification_info_with_options
 
 COMPACT_SUMMARY_FIELDS = (
@@ -81,7 +82,17 @@ def _pick_latest_message(messages: Iterable[Dict[str, Any]]) -> Optional[Dict[st
     return max(normalized, key=lambda item: parse_received_at(item.get("received_at")))
 
 
-def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+def _resolve_account_verification_policy(account_id: int) -> Dict[str, Any]:
+    try:
+        account = accounts_repo.get_account_by_id(int(account_id)) or {}
+        group_id = account.get("group_id")
+        group = groups_repo.get_group_by_id(int(group_id)) if group_id else None
+        return groups_repo.resolve_group_verification_policy(group=group)
+    except Exception:
+        return {"code_length": "6-6", "code_regex": None}
+
+
+def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]], *, policy: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, str]]:
     latest_match: Optional[Dict[str, str]] = None
 
     for message in messages:
@@ -95,7 +106,13 @@ def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]]) -> Opt
         }
 
         try:
-            result = extract_verification_info_with_options(candidate_payload, code_source="all", code_length="6-6")
+            resolved_policy = policy or {"code_length": "6-6", "code_regex": None}
+            result = extract_verification_info_with_options(
+                candidate_payload,
+                code_source="all",
+                code_regex=resolved_policy.get("code_regex"),
+                code_length=resolved_policy.get("code_length"),
+            )
             result = apply_confidence_gate(result, enforce_mutual_exclusion=False)
         except ValueError:
             continue
@@ -171,7 +188,8 @@ def update_summary_from_message_list(
     current = accounts_repo.get_account_compact_summary(account_id) or empty_compact_summary()
     normalized_messages = [normalize_message_summary(message, folder=folder) for message in messages or []]
     latest = _pick_latest_message(normalized_messages)
-    latest_verification = _pick_latest_verification_message(normalized_messages)
+    verification_policy = _resolve_account_verification_policy(account_id)
+    latest_verification = _pick_latest_verification_message(normalized_messages, policy=verification_policy)
     updated = _merge_latest_email(current, latest)
     if latest_verification:
         updated = _merge_latest_verification(

--- a/outlook_web/services/verification_code_extraction.py
+++ b/outlook_web/services/verification_code_extraction.py
@@ -10,9 +10,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import html
 import re
+from dataclasses import dataclass
 from html.parser import HTMLParser
 from typing import Any, Dict, List, Optional
 
@@ -102,7 +102,6 @@ LINK_CONTEXT_PHRASES = [
 ]
 
 
-
 @dataclass(frozen=True)
 class VerificationInput:
     """Normalized verification extraction input."""
@@ -147,6 +146,7 @@ class VerificationPolicy:
     code_source: str = "all"
     prefer_link_keywords: list[str] | None = None
     enforce_mutual_exclusion: bool = True
+
 
 class HTMLTextExtractor(HTMLParser):
     """HTML 转纯文本提取器"""
@@ -777,6 +777,7 @@ def extract_verification(
         enforce_mutual_exclusion=resolved_policy.enforce_mutual_exclusion,
     )
 
+
 def apply_confidence_gate(extracted: Dict[str, Any], *, enforce_mutual_exclusion: bool = True) -> Dict[str, Any]:
     """
     对 extract_verification_info_with_options() 的返回结果应用置信度门控。
@@ -813,4 +814,3 @@ def apply_confidence_gate(extracted: Dict[str, Any], *, enforce_mutual_exclusion
         "high" if result.get("code_confidence") == "high" or result.get("link_confidence") == "high" else "low"
     )
     return result
-

--- a/outlook_web/services/verification_code_extraction.py
+++ b/outlook_web/services/verification_code_extraction.py
@@ -1,0 +1,816 @@
+"""
+验证码提取服务模块
+
+提供从邮件内容中提取验证码和链接的功能，包括：
+- 智能验证码识别（基于关键词）
+- 保底验证码提取（正则匹配 + 过滤）
+- 链接提取（HTTP/HTTPS）
+- 邮件内容提取（HTML转纯文本）
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import re
+from html.parser import HTMLParser
+from typing import Any, Dict, List, Optional
+
+# 验证码关键词列表（支持中英文）
+VERIFICATION_KEYWORDS = [
+    "验证码",
+    "code",
+    "验证",
+    "verification",
+    "OTP",
+    "动态码",
+    "校验码",
+    "verify code",
+    "confirmation code",
+    "security code",
+    "验证码是",
+    "your code",
+    "code is",
+    "激活码",
+    "短信验证码",
+]
+
+# 验证码模式（4-8位数字或字母，必须包含至少一个数字）
+VERIFICATION_PATTERN = r"\b[A-Z0-9]{4,8}\b"
+
+# 带连字符的字母数字验证码，例如 x.ai 的 84A-KMN。
+# x.ai HTML 常把验证码紧贴在句末（如 address.84A-KMNIf），因此允许验证码后接英文单词首字母。
+HYPHENATED_VERIFICATION_PATTERN = r"(?<![A-Z0-9])([A-Z0-9]{2,4}-[A-Z0-9]{2,4})(?=$|[^A-Z0-9-]|[A-Z][a-z])"
+
+# 验证码语境提权：出现这些短语时允许识别带连字符验证码，降低订单号/追踪号误判
+CODE_CONTEXT_PHRASES = [
+    "validate your email",
+    "validate your email address",
+    "code below",
+    "xai account",
+    "x.ai",
+    "support@x.ai",
+    "verification code",
+    "confirm your email",
+    "verify your email",
+    "your code",
+    "the code below",
+]
+
+# 链接正则表达式
+LINK_PATTERN = r'https?://[^\s<>"{}|\\^`\[\]]+'
+
+# 对外/参数化提取：验证链接优先关键词
+DEFAULT_LINK_KEYWORDS = [
+    "verify",
+    "confirmation",
+    "confirm",
+    "activate",
+    "validation",
+]
+
+# 链接语境提权：仅与"验证/激活账户/确认邮箱"强相关的完整短语
+# 必须带对象名词（email/account/邮箱/账户），避免 "confirm your order" 等交易邮件误触
+LINK_CONTEXT_PHRASES = [
+    "verify your email",
+    "verify your account",
+    "verify your address",
+    "confirm your email",
+    "confirm your account",
+    "confirm your address",
+    "activate your email",
+    "activate your account",
+    "email verification",
+    "account verification",
+    "验证您的邮箱",
+    "验证你的邮箱",
+    "验证您的账户",
+    "验证你的账户",
+    "验证您的账号",
+    "验证你的账号",
+    "确认您的邮箱",
+    "确认你的邮箱",
+    "确认您的账户",
+    "确认你的账户",
+    "激活您的账户",
+    "激活你的账户",
+    "激活您的邮箱",
+    "激活你的邮箱",
+    "邮箱验证",
+    "账号验证",
+    "账户验证",
+]
+
+
+
+@dataclass(frozen=True)
+class VerificationInput:
+    """Normalized verification extraction input."""
+
+    subject: str = ""
+    text: str = ""
+    body_preview: str = ""
+    html: str = ""
+    body_content: str = ""
+    body_content_type: str = ""
+
+    @classmethod
+    def from_email(cls, email: Dict[str, Any]) -> "VerificationInput":
+        payload = email or {}
+        return cls(
+            subject=str(payload.get("subject") or ""),
+            text=str(payload.get("body") or ""),
+            body_preview=str(payload.get("body_preview") or payload.get("bodyPreview") or ""),
+            html=str(payload.get("body_html") or payload.get("html_content") or ""),
+            body_content=str(payload.get("bodyContent") or ""),
+            body_content_type=str(payload.get("bodyContentType") or ""),
+        )
+
+    def as_email(self) -> Dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "body": self.text,
+            "body_preview": self.body_preview,
+            "body_html": self.html,
+            "html_content": self.html,
+            "bodyContent": self.body_content,
+            "bodyContentType": self.body_content_type,
+        }
+
+
+@dataclass(frozen=True)
+class VerificationPolicy:
+    """Runtime extraction policy resolved from request/group/default settings."""
+
+    code_regex: str | None = None
+    code_length: str | None = None
+    code_source: str = "all"
+    prefer_link_keywords: list[str] | None = None
+    enforce_mutual_exclusion: bool = True
+
+class HTMLTextExtractor(HTMLParser):
+    """HTML 转纯文本提取器"""
+
+    def __init__(self):
+        super().__init__()
+        self.text_parts = []
+        self._skip_tags = {"style", "script", "head", "meta", "link"}
+        self._current_skip = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() in self._skip_tags:
+            self._current_skip = True
+
+    def handle_endtag(self, tag):
+        if tag.lower() in self._skip_tags:
+            self._current_skip = False
+
+    def handle_data(self, data):
+        if not self._current_skip and data.strip():
+            self.text_parts.append(data.strip())
+
+    def get_text(self) -> str:
+        return " ".join(self.text_parts)
+
+
+def _is_valid_hyphenated_code(code: str) -> bool:
+    """校验带连字符验证码：两段字母数字、总长 4-10。
+
+    x.ai 常见两种形态：
+    - 含数字：84A-KMN
+    - 全大写字母：NJF-KUU（无数字，但两段均 >=3 且总长 >=6）
+    """
+    if not code or "-" not in code:
+        return False
+
+    parts = code.split("-")
+    if len(parts) != 2:
+        return False
+    if not all(part.isalnum() for part in parts):
+        return False
+
+    alnum = "".join(parts)
+    if not (4 <= len(alnum) <= 10):
+        return False
+    if any(c.isdigit() for c in alnum):
+        return True
+    # x.ai 全字母验证码（如 NJF-KUU）
+    return len(alnum) >= 6 and all(len(part) >= 3 for part in parts) and alnum.isalpha()
+
+
+def _has_code_context(email_content: str) -> bool:
+    content_lower = email_content.lower()
+    return any(phrase.lower() in content_lower for phrase in CODE_CONTEXT_PHRASES)
+
+
+def _find_hyphenated_code_in_text(text: str) -> Optional[str]:
+    if not text:
+        return None
+
+    for match in re.finditer(HYPHENATED_VERIFICATION_PATTERN, text, re.IGNORECASE):
+        code = match.group(1)
+        if _is_valid_hyphenated_code(code):
+            return code
+    return None
+
+
+def _smart_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    """在验证码关键词附近搜索带连字符验证码。"""
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        code = _find_hyphenated_code_in_text(email_content[start:end])
+        if code:
+            return code
+    return None
+
+
+def _fallback_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    """在验证码语境明确时，从全文搜索带连字符验证码。"""
+    if not email_content or not _has_code_context(email_content):
+        return None
+    return _find_hyphenated_code_in_text(email_content)
+
+
+def smart_extract_verification_code(email_content: str) -> Optional[str]:
+    """
+    智能提取验证码（基于关键词）
+
+    算法：
+    1. 遍历关键词列表
+    2. 在邮件内容中查找关键词位置
+    3. 在关键词前后 50 个字符范围内搜索验证码模式
+    4. 返回第一个匹配的验证码（必须包含数字）
+
+    Args:
+        email_content: 邮件文本内容
+
+    Returns:
+        验证码字符串，未找到返回 None
+    """
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+
+        if pos != -1:
+            # 提取关键词前后 50 个字符的上下文
+            start = max(0, pos - 50)
+            end = min(len(email_content), pos + len(keyword) + 50)
+            context = email_content[start:end]
+
+            # 在上下文中搜索验证码
+            matches = re.findall(VERIFICATION_PATTERN, context, re.IGNORECASE)
+            if matches:
+                # 过滤掉纯字母的匹配（验证码通常包含数字）
+                for match in matches:
+                    if any(c.isdigit() for c in match):
+                        return match
+
+    hyphenated_code = _smart_extract_hyphenated_verification_code(email_content)
+    if hyphenated_code:
+        return hyphenated_code
+
+    return None
+
+
+def fallback_extract_verification_code(email_content: str) -> Optional[str]:
+    """
+    保底提取验证码（正则匹配 + 过滤）
+
+    算法：
+    1. 提取所有 4-8 位的数字/字母组合
+    2. 过滤掉常见的非验证码模式（日期、时间等）
+    3. 返回第一个匹配项
+
+    Args:
+        email_content: 邮件文本内容
+
+    Returns:
+        验证码字符串，未找到返回 None
+    """
+    if not email_content:
+        return None
+
+    # 提取所有可能的验证码
+    matches = re.findall(VERIFICATION_PATTERN, email_content, re.IGNORECASE)
+
+    # 过滤规则
+    filtered = []
+    for match in matches:
+        # 必须包含至少一个数字
+        if not any(c.isdigit() for c in match):
+            continue
+
+        # 排除纯数字且长度为 4 的（可能是年份）
+        if match.isdigit() and len(match) == 4:
+            year = int(match)
+            if 1900 <= year <= 2100:
+                continue
+
+        # 排除常见的时间格式（如 1234 可能是 12:34）
+        if match.isdigit() and len(match) == 4:
+            hour = int(match[:2])
+            minute = int(match[2:])
+            if 0 <= hour <= 23 and 0 <= minute <= 59:
+                continue
+
+        # 排除常见的 4 位数字编号（如 2024、2025 等年份）
+        if match.isdigit() and len(match) == 4:
+            # 年份范围检查
+            num = int(match)
+            if 2020 <= num <= 2030:
+                continue
+
+        filtered.append(match)
+
+    if filtered:
+        return filtered[0]
+
+    return _fallback_extract_hyphenated_verification_code(email_content)
+
+
+def extract_links(email_content: str) -> List[str]:
+    """
+    提取所有 HTTP/HTTPS 链接
+
+    算法：
+    1. 使用正则表达式提取所有链接
+    2. 去重并保持顺序
+    3. 清理链接末尾的标点符号
+
+    Args:
+        email_content: 邮件文本内容
+
+    Returns:
+        去重后的链接列表
+    """
+    if not email_content:
+        return []
+
+    matches = re.findall(LINK_PATTERN, email_content, re.IGNORECASE)
+
+    # 清理链接（移除末尾的标点符号）
+    cleaned_links = []
+    for link in matches:
+        # 移除末尾的标点符号
+        cleaned = link.rstrip(".,;:!?)>'\"")
+        cleaned_links.append(cleaned)
+
+    # 去重并保持顺序
+    seen = set()
+    unique_links = []
+    for link in cleaned_links:
+        if link not in seen:
+            seen.add(link)
+            unique_links.append(link)
+
+    return unique_links
+
+
+def extract_email_text(email: Dict[str, Any]) -> str:
+    """
+    从邮件对象提取纯文本内容
+
+    优先级：
+    1. body（纯文本）
+    2. body_html（HTML 转纯文本）
+    3. body_preview（预览文本）
+
+    Args:
+        email: 邮件对象字典
+
+    Returns:
+        提取的纯文本内容
+
+    Raises:
+        ValueError: 邮件内容为空
+    """
+    # 优先使用纯文本
+    if email.get("body") and email["body"].strip():
+        return email["body"].strip()
+
+    # 其次使用 HTML 转纯文本
+    if email.get("body_html") and email["body_html"].strip():
+        parser = HTMLTextExtractor()
+        try:
+            parser.feed(email["body_html"])
+            text = parser.get_text()
+            # 解码 HTML 实体
+            text = html.unescape(text)
+            if text.strip():
+                return text.strip()
+        except Exception:
+            pass
+
+    # 再次尝试使用 bodyContent（Graph API 格式）
+    if email.get("bodyContent") and email["bodyContent"].strip():
+        content = email["bodyContent"]
+        # 如果是 HTML，需要转换
+        if email.get("bodyContentType") == "html":
+            parser = HTMLTextExtractor()
+            try:
+                parser.feed(content)
+                text = parser.get_text()
+                text = html.unescape(text)
+                if text.strip():
+                    return text.strip()
+            except Exception:
+                pass
+        else:
+            return content.strip()
+
+    # 最后使用预览文本
+    if email.get("body_preview") and email["body_preview"].strip():
+        return email["body_preview"].strip()
+
+    # 使用 subject 作为补充
+    if email.get("subject") and email["subject"].strip():
+        return email["subject"].strip()
+
+    return ""
+
+
+def extract_verification_info_from_text(email_content: str) -> Dict[str, Any]:
+    """
+    从文本内容提取验证信息
+
+    Args:
+        email_content: 邮件文本内容
+
+    Returns:
+        包含验证码、链接和格式化输出的字典
+    """
+    # 提取验证码（智能识别 + 保底）
+    verification_code = smart_extract_verification_code(email_content)
+    if not verification_code:
+        verification_code = fallback_extract_verification_code(email_content)
+
+    # 提取链接
+    links = extract_links(email_content)
+
+    # 格式化输出
+    parts = []
+    if verification_code:
+        parts.append(verification_code)
+    parts.extend(links)
+
+    formatted = " ".join(parts) if parts else None
+
+    return {
+        "verification_code": verification_code,
+        "links": links,
+        "formatted": formatted,
+    }
+
+
+def extract_verification_info(email: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    从邮件对象提取验证信息的完整流程
+
+    Args:
+        email: 邮件对象字典
+
+    Returns:
+        包含验证码、链接和格式化输出的字典
+
+    Raises:
+        ValueError: 未找到验证信息
+    """
+    # 提取邮件文本内容
+    email_content = extract_email_text(email)
+
+    if not email_content:
+        raise ValueError("邮件内容为空")
+
+    # 提取验证信息
+    result = extract_verification_info_from_text(email_content)
+
+    if not result["formatted"]:
+        raise ValueError("未找到验证信息")
+
+    return result
+
+
+def extract_content_text_without_subject(email: Dict[str, Any]) -> str:
+    """
+    仅提取邮件正文/预览（不回退到 subject）。
+
+    注意：extract_email_text() 会在末尾回退 subject；该函数用于 code_source=content 时严格遵循语义。
+    """
+    # 优先使用纯文本
+    if email.get("body") and str(email["body"]).strip():
+        return str(email["body"]).strip()
+
+    # 其次使用 HTML 转纯文本
+    if email.get("body_html") and str(email["body_html"]).strip():
+        parser = HTMLTextExtractor()
+        try:
+            parser.feed(str(email["body_html"]))
+            text = html.unescape(parser.get_text() or "")
+            return text.strip()
+        except Exception:
+            return ""
+
+    # Graph API 格式 bodyContent/bodyContentType
+    if email.get("bodyContent") and str(email["bodyContent"]).strip():
+        content = str(email["bodyContent"])
+        if str(email.get("bodyContentType") or "").lower() == "html":
+            parser = HTMLTextExtractor()
+            try:
+                parser.feed(content)
+                text = html.unescape(parser.get_text() or "")
+                return text.strip()
+            except Exception:
+                return ""
+        return content.strip()
+
+    if email.get("body_preview") and str(email["body_preview"]).strip():
+        return str(email["body_preview"]).strip()
+
+    return ""
+
+
+def _parse_code_length(code_length: str) -> tuple[int, int]:
+    m = re.match(r"^(\d+)-(\d+)$", str(code_length or "").strip())
+    if not m:
+        raise ValueError("code_length 参数无效")
+    min_len = int(m.group(1))
+    max_len = int(m.group(2))
+    if min_len <= 0 or max_len <= 0 or min_len > max_len:
+        raise ValueError("code_length 参数无效")
+    return min_len, max_len
+
+
+def _build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.Pattern:
+    if code_regex:
+        try:
+            return re.compile(code_regex)
+        except re.error as exc:
+            raise ValueError("code_regex 参数无效") from exc
+
+    if code_length:
+        min_len, max_len = _parse_code_length(code_length)
+        return re.compile(rf"\b[A-Za-z0-9]{{{min_len},{max_len}}}\b")
+
+    # 默认：4-8 位数字验证码；字母数字验证码由 group/request 的 code_length 策略启用。
+    return re.compile(r"\b\d{4,8}\b")
+
+
+def _smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern) -> Optional[str]:
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        context = email_content[start:end]
+
+        for m in code_re.finditer(context):
+            value = m.group(0)
+            if value and any(c.isdigit() for c in value):
+                return value
+
+    return None
+
+
+def _fallback_extract_code(email_content: str, code_re: re.Pattern) -> Optional[str]:
+    if not email_content:
+        return None
+
+    candidates: List[str] = []
+    for m in code_re.finditer(email_content):
+        value = m.group(0) or ""
+        if not value:
+            continue
+
+        # 与现有提取器保持一致：必须包含至少一个数字
+        if not any(c.isdigit() for c in value):
+            continue
+
+        # 过滤常见误判（仅对纯数字候选生效）
+        if value.isdigit() and len(value) == 4:
+            year = int(value)
+            if 1900 <= year <= 2100:
+                continue
+            hour = int(value[:2])
+            minute = int(value[2:])
+            if 0 <= hour <= 23 and 0 <= minute <= 59:
+                continue
+            num = int(value)
+            if 2020 <= num <= 2030:
+                continue
+
+        candidates.append(value)
+
+    return candidates[0] if candidates else None
+
+
+def _pick_preferred_link(links: List[str], prefer_link_keywords: List[str]) -> Optional[str]:
+    if not links:
+        return None
+
+    keywords = [k.lower() for k in (prefer_link_keywords or []) if k]
+    if keywords:
+        for keyword in keywords:
+            for link in links:
+                if keyword in (link or "").lower():
+                    return link
+
+    return links[0]
+
+
+def extract_verification_info_with_options(
+    email: Dict[str, Any],
+    *,
+    code_regex: str | None = None,
+    code_length: str | None = None,
+    code_source: str = "all",
+    prefer_link_keywords: list[str] | None = None,
+    enforce_mutual_exclusion: bool = True,
+) -> Dict[str, Any]:
+    """
+    在现有提取器基础上支持：
+    - 自定义验证码正则（code_regex）
+    - 自定义验证码长度范围（code_length，如 4-8 / 6-6）
+    - 提取来源限定（subject/content/html/all）
+    - 验证链接关键词优先级（prefer_link_keywords）
+
+    返回结构为兼容扩展字典：
+    - verification_code
+    - verification_link
+    - links
+    - formatted
+    - match_source
+    - confidence          (向后兼容：code/link 中较高者)
+    - code_confidence      (high=关键词命中或调用方指定code_regex命中, low=仅 fallback 或未命中)
+    - link_confidence      (high=链接含验证关键词或邮件正文含强验证语境短语, low=任意首链接且无验证语境)
+
+    注意：该函数主要服务外部 API，不主动抛“未找到验证码/链接”的异常，方便上层按需映射错误码。
+    """
+    subject = str(email.get("subject") or "").strip()
+    content = extract_content_text_without_subject(email)
+    html_content = str(email.get("body_html") or email.get("html_content") or "").strip()
+
+    source = str(code_source or "all").strip().lower()
+    if source == "subject":
+        source_text = subject
+        match_source = "subject"
+    elif source == "content":
+        source_text = content
+        match_source = "content"
+    elif source == "html":
+        if html_content:
+            parser = HTMLTextExtractor()
+            try:
+                parser.feed(html_content)
+                source_text = html.unescape(parser.get_text() or "").strip()
+            except Exception:
+                source_text = html_content
+        else:
+            source_text = ""
+        match_source = "html"
+    else:
+        # all：content 已含 HTML 转纯文本；勿再拼接原始 HTML，避免 CSS 色值（如 #333333）误判
+        source_text = f"{subject} {content}".strip()
+        match_source = "all"
+
+    code_re = _build_code_regex(code_regex=code_regex, code_length=code_length)
+    # 仅 code_regex 具有判别力，code_length 只是宽度约束，不自动提权
+    caller_directed_code = bool(code_regex)
+
+    # ── 验证码提取 & 置信度 ──
+    verification_code = _smart_extract_code_by_keywords(source_text, code_re)
+    code_confidence: str = "high" if verification_code else "low"
+    if not verification_code:
+        verification_code = _fallback_extract_code(source_text, code_re)
+        # 调用方显式指定了 code_regex（强判别力正则）→ 提取命中即视为可信
+        if verification_code and caller_directed_code:
+            code_confidence = "high"
+    if not verification_code:
+        verification_code = _smart_extract_hyphenated_verification_code(source_text)
+        if verification_code:
+            code_confidence = "high"
+    if not verification_code:
+        verification_code = _fallback_extract_hyphenated_verification_code(source_text)
+        if verification_code:
+            code_confidence = "high"
+
+    # ── 链接提取 & 置信度 ──
+    links = extract_links(f"{subject} {content} {html_content}".strip())
+    prefer_keywords = prefer_link_keywords or DEFAULT_LINK_KEYWORDS
+
+    verification_link = None
+    link_confidence: str = "low"
+    should_pick_link = (not enforce_mutual_exclusion) or (not verification_code)
+    if should_pick_link:
+        verification_link = _pick_preferred_link(links, prefer_keywords)
+        if verification_link:
+            # 优先检查 URL 本身是否含验证关键词
+            for kw in prefer_keywords:
+                if kw and kw.lower() in verification_link.lower():
+                    link_confidence = "high"
+                    break
+            # URL 不含关键词时，检查邮件正文/主题是否有强验证语境短语
+            if link_confidence != "high":
+                full_text_lower = f"{subject} {content}".lower()
+                for phrase in LINK_CONTEXT_PHRASES:
+                    if phrase.lower() in full_text_lower:
+                        link_confidence = "high"
+                        break
+
+    # 总 confidence 向后兼容：取 code / link 中较高者
+    confidence = "high" if code_confidence == "high" or link_confidence == "high" else "low"
+
+    parts: List[str] = []
+    if verification_code:
+        parts.append(verification_code)
+    if verification_link:
+        parts.append(verification_link)
+    formatted = " ".join(parts) if parts else None
+
+    return {
+        "verification_code": verification_code,
+        "verification_link": verification_link,
+        "links": links,
+        "formatted": formatted,
+        "match_source": match_source,
+        "confidence": confidence,
+        "code_confidence": code_confidence,
+        "link_confidence": link_confidence,
+    }
+
+
+def extract_verification(
+    payload: VerificationInput | Dict[str, Any],
+    policy: VerificationPolicy | None = None,
+) -> Dict[str, Any]:
+    """Run the unified verification extraction pipeline."""
+    normalized = payload if isinstance(payload, VerificationInput) else VerificationInput.from_email(payload)
+    resolved_policy = policy or VerificationPolicy()
+    return extract_verification_info_with_options(
+        normalized.as_email(),
+        code_regex=resolved_policy.code_regex,
+        code_length=resolved_policy.code_length,
+        code_source=resolved_policy.code_source,
+        prefer_link_keywords=resolved_policy.prefer_link_keywords,
+        enforce_mutual_exclusion=resolved_policy.enforce_mutual_exclusion,
+    )
+
+def apply_confidence_gate(extracted: Dict[str, Any], *, enforce_mutual_exclusion: bool = True) -> Dict[str, Any]:
+    """
+    对 extract_verification_info_with_options() 的返回结果应用置信度门控。
+
+    规则：
+    - code_confidence != "high"  → verification_code 置 None
+    - link_confidence != "high"  → verification_link 置 None
+    - 重算 formatted 与 confidence 以保持一致
+
+    用途：外部 API 和临时邮箱验证码提取均应调用此函数，
+    确保两条路径使用完全相同的门控标准，避免逻辑漂移。
+
+    Args:
+        extracted: extract_verification_info_with_options() 的返回值（原地修改一份拷贝）
+
+    Returns:
+        门控后的字典（不修改原始 extracted，返回新字典）
+    """
+    result = dict(extracted)
+
+    if result.get("code_confidence") != "high":
+        result["verification_code"] = None
+    if result.get("link_confidence") != "high":
+        result["verification_link"] = None
+
+    # 产品策略：严格互斥（code 优先）
+    if enforce_mutual_exclusion and result.get("verification_code"):
+        result["verification_link"] = None
+        result["link_confidence"] = "low"
+
+    parts = [v for v in (result.get("verification_code"), result.get("verification_link")) if v]
+    result["formatted"] = " ".join(parts) if parts else None
+    result["confidence"] = (
+        "high" if result.get("code_confidence") == "high" or result.get("link_confidence") == "high" else "low"
+    )
+    return result
+

--- a/outlook_web/services/verification_extractor.py
+++ b/outlook_web/services/verification_extractor.py
@@ -20,11 +20,11 @@ from outlook_web.services.verification_code_extraction import (
     CODE_CONTEXT_PHRASES,
     DEFAULT_LINK_KEYWORDS,
     HYPHENATED_VERIFICATION_PATTERN,
-    HTMLTextExtractor,
     LINK_CONTEXT_PHRASES,
     LINK_PATTERN,
     VERIFICATION_KEYWORDS,
     VERIFICATION_PATTERN,
+    HTMLTextExtractor,
     VerificationInput,
     VerificationPolicy,
     _build_code_regex,
@@ -38,8 +38,12 @@ from outlook_web.services.verification_code_extraction import (
     _smart_extract_code_by_keywords,
     _smart_extract_hyphenated_verification_code,
     apply_confidence_gate,
-    extract_content_text_without_subject,
+)
+from outlook_web.services.verification_code_extraction import extract_content_text_without_subject
+from outlook_web.services.verification_code_extraction import (
     extract_content_text_without_subject as _extract_content_text_without_subject,
+)
+from outlook_web.services.verification_code_extraction import (
     extract_email_text,
     extract_links,
     extract_verification,
@@ -92,6 +96,7 @@ __all__ = [
     "probe_verification_ai_runtime",
     "smart_extract_verification_code",
 ]
+
 
 def get_verification_ai_runtime_config() -> Dict[str, Any]:
     """读取系统级验证码 AI 配置。"""

--- a/outlook_web/services/verification_extractor.py
+++ b/outlook_web/services/verification_extractor.py
@@ -1,766 +1,97 @@
 """
-验证码提取服务模块
+验证码提取服务兼容入口
 
-提供从邮件内容中提取验证码和链接的功能，包括：
-- 智能验证码识别（基于关键词）
-- 保底验证码提取（正则匹配 + 过滤）
-- 链接提取（HTTP/HTTPS）
-- 邮件内容提取（HTML转纯文本）
+核心验证码抽取规则已收敛到 verification_code_extraction.py；本模块保留旧导入路径，
+并继续承载验证码 AI fallback 相关逻辑。
 """
 
 from __future__ import annotations
 
-import html
 import json
 import logging
 import re
 import time
-from html.parser import HTMLParser
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import requests
 
 from outlook_web.repositories import settings as settings_repo
-
-# 验证码关键词列表（支持中英文）
-VERIFICATION_KEYWORDS = [
-    "验证码",
-    "code",
-    "验证",
-    "verification",
-    "OTP",
-    "动态码",
-    "校验码",
-    "verify code",
-    "confirmation code",
-    "security code",
-    "验证码是",
-    "your code",
-    "code is",
-    "激活码",
-    "短信验证码",
-]
-
-# 验证码模式（4-8位数字或字母，必须包含至少一个数字）
-VERIFICATION_PATTERN = r"\b[A-Z0-9]{4,8}\b"
-
-# 带连字符的字母数字验证码，例如 x.ai 的 84A-KMN。
-# x.ai HTML 常把验证码紧贴在句末（如 address.84A-KMNIf），因此允许验证码后接英文单词首字母。
-HYPHENATED_VERIFICATION_PATTERN = r"(?<![A-Z0-9])([A-Z0-9]{2,4}-[A-Z0-9]{2,4})(?=$|[^A-Z0-9-]|[A-Z][a-z])"
-
-# 验证码语境提权：出现这些短语时允许识别带连字符验证码，降低订单号/追踪号误判
-CODE_CONTEXT_PHRASES = [
-    "validate your email",
-    "validate your email address",
-    "code below",
-    "xai account",
-    "x.ai",
-    "support@x.ai",
-    "verification code",
-    "confirm your email",
-    "verify your email",
-    "your code",
-    "the code below",
-]
-
-# 链接正则表达式
-LINK_PATTERN = r'https?://[^\s<>"{}|\\^`\[\]]+'
-
-# 对外/参数化提取：验证链接优先关键词
-DEFAULT_LINK_KEYWORDS = [
-    "verify",
-    "confirmation",
-    "confirm",
-    "activate",
-    "validation",
-]
-
-# 链接语境提权：仅与"验证/激活账户/确认邮箱"强相关的完整短语
-# 必须带对象名词（email/account/邮箱/账户），避免 "confirm your order" 等交易邮件误触
-LINK_CONTEXT_PHRASES = [
-    "verify your email",
-    "verify your account",
-    "verify your address",
-    "confirm your email",
-    "confirm your account",
-    "confirm your address",
-    "activate your email",
-    "activate your account",
-    "email verification",
-    "account verification",
-    "验证您的邮箱",
-    "验证你的邮箱",
-    "验证您的账户",
-    "验证你的账户",
-    "验证您的账号",
-    "验证你的账号",
-    "确认您的邮箱",
-    "确认你的邮箱",
-    "确认您的账户",
-    "确认你的账户",
-    "激活您的账户",
-    "激活你的账户",
-    "激活您的邮箱",
-    "激活你的邮箱",
-    "邮箱验证",
-    "账号验证",
-    "账户验证",
-]
+from outlook_web.services.verification_code_extraction import (
+    CODE_CONTEXT_PHRASES,
+    DEFAULT_LINK_KEYWORDS,
+    HYPHENATED_VERIFICATION_PATTERN,
+    HTMLTextExtractor,
+    LINK_CONTEXT_PHRASES,
+    LINK_PATTERN,
+    VERIFICATION_KEYWORDS,
+    VERIFICATION_PATTERN,
+    VerificationInput,
+    VerificationPolicy,
+    _build_code_regex,
+    _fallback_extract_code,
+    _fallback_extract_hyphenated_verification_code,
+    _find_hyphenated_code_in_text,
+    _has_code_context,
+    _is_valid_hyphenated_code,
+    _parse_code_length,
+    _pick_preferred_link,
+    _smart_extract_code_by_keywords,
+    _smart_extract_hyphenated_verification_code,
+    apply_confidence_gate,
+    extract_content_text_without_subject,
+    extract_content_text_without_subject as _extract_content_text_without_subject,
+    extract_email_text,
+    extract_links,
+    extract_verification,
+    extract_verification_info,
+    extract_verification_info_from_text,
+    extract_verification_info_with_options,
+    fallback_extract_verification_code,
+    smart_extract_verification_code,
+)
 
 VERIFICATION_AI_SCHEMA_VERSION = "verification_ai_v1"
 _LOGGER = logging.getLogger("outlook_web.services.verification_extractor")
 
-
-class HTMLTextExtractor(HTMLParser):
-    """HTML 转纯文本提取器"""
-
-    def __init__(self):
-        super().__init__()
-        self.text_parts = []
-        self._skip_tags = {"style", "script", "head", "meta", "link"}
-        self._current_skip = False
-
-    def handle_starttag(self, tag, attrs):
-        if tag.lower() in self._skip_tags:
-            self._current_skip = True
-
-    def handle_endtag(self, tag):
-        if tag.lower() in self._skip_tags:
-            self._current_skip = False
-
-    def handle_data(self, data):
-        if not self._current_skip and data.strip():
-            self.text_parts.append(data.strip())
-
-    def get_text(self) -> str:
-        return " ".join(self.text_parts)
-
-
-def _is_valid_hyphenated_code(code: str) -> bool:
-    """校验带连字符验证码：两段字母数字、总长 4-10。
-
-    x.ai 常见两种形态：
-    - 含数字：84A-KMN
-    - 全大写字母：NJF-KUU（无数字，但两段均 >=3 且总长 >=6）
-    """
-    if not code or "-" not in code:
-        return False
-
-    parts = code.split("-")
-    if len(parts) != 2:
-        return False
-    if not all(part.isalnum() for part in parts):
-        return False
-
-    alnum = "".join(parts)
-    if not (4 <= len(alnum) <= 10):
-        return False
-    if any(c.isdigit() for c in alnum):
-        return True
-    # x.ai 全字母验证码（如 NJF-KUU）
-    return len(alnum) >= 6 and all(len(part) >= 3 for part in parts) and alnum.isalpha()
-
-
-def _has_code_context(email_content: str) -> bool:
-    content_lower = email_content.lower()
-    return any(phrase.lower() in content_lower for phrase in CODE_CONTEXT_PHRASES)
-
-
-def _find_hyphenated_code_in_text(text: str) -> Optional[str]:
-    if not text:
-        return None
-
-    for match in re.finditer(HYPHENATED_VERIFICATION_PATTERN, text, re.IGNORECASE):
-        code = match.group(1)
-        if _is_valid_hyphenated_code(code):
-            return code
-    return None
-
-
-def _smart_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
-    """在验证码关键词附近搜索带连字符验证码。"""
-    if not email_content:
-        return None
-
-    content_lower = email_content.lower()
-    for keyword in VERIFICATION_KEYWORDS:
-        keyword_lower = keyword.lower()
-        pos = content_lower.find(keyword_lower)
-        if pos == -1:
-            continue
-
-        start = max(0, pos - 50)
-        end = min(len(email_content), pos + len(keyword) + 50)
-        code = _find_hyphenated_code_in_text(email_content[start:end])
-        if code:
-            return code
-    return None
-
-
-def _fallback_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
-    """在验证码语境明确时，从全文搜索带连字符验证码。"""
-    if not email_content or not _has_code_context(email_content):
-        return None
-    return _find_hyphenated_code_in_text(email_content)
-
-
-def smart_extract_verification_code(email_content: str) -> Optional[str]:
-    """
-    智能提取验证码（基于关键词）
-
-    算法：
-    1. 遍历关键词列表
-    2. 在邮件内容中查找关键词位置
-    3. 在关键词前后 50 个字符范围内搜索验证码模式
-    4. 返回第一个匹配的验证码（必须包含数字）
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        验证码字符串，未找到返回 None
-    """
-    if not email_content:
-        return None
-
-    content_lower = email_content.lower()
-
-    for keyword in VERIFICATION_KEYWORDS:
-        keyword_lower = keyword.lower()
-        pos = content_lower.find(keyword_lower)
-
-        if pos != -1:
-            # 提取关键词前后 50 个字符的上下文
-            start = max(0, pos - 50)
-            end = min(len(email_content), pos + len(keyword) + 50)
-            context = email_content[start:end]
-
-            # 在上下文中搜索验证码
-            matches = re.findall(VERIFICATION_PATTERN, context, re.IGNORECASE)
-            if matches:
-                # 过滤掉纯字母的匹配（验证码通常包含数字）
-                for match in matches:
-                    if any(c.isdigit() for c in match):
-                        return match
-
-    hyphenated_code = _smart_extract_hyphenated_verification_code(email_content)
-    if hyphenated_code:
-        return hyphenated_code
-
-    return None
-
-
-def fallback_extract_verification_code(email_content: str) -> Optional[str]:
-    """
-    保底提取验证码（正则匹配 + 过滤）
-
-    算法：
-    1. 提取所有 4-8 位的数字/字母组合
-    2. 过滤掉常见的非验证码模式（日期、时间等）
-    3. 返回第一个匹配项
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        验证码字符串，未找到返回 None
-    """
-    if not email_content:
-        return None
-
-    # 提取所有可能的验证码
-    matches = re.findall(VERIFICATION_PATTERN, email_content, re.IGNORECASE)
-
-    # 过滤规则
-    filtered = []
-    for match in matches:
-        # 必须包含至少一个数字
-        if not any(c.isdigit() for c in match):
-            continue
-
-        # 排除纯数字且长度为 4 的（可能是年份）
-        if match.isdigit() and len(match) == 4:
-            year = int(match)
-            if 1900 <= year <= 2100:
-                continue
-
-        # 排除常见的时间格式（如 1234 可能是 12:34）
-        if match.isdigit() and len(match) == 4:
-            hour = int(match[:2])
-            minute = int(match[2:])
-            if 0 <= hour <= 23 and 0 <= minute <= 59:
-                continue
-
-        # 排除常见的 4 位数字编号（如 2024、2025 等年份）
-        if match.isdigit() and len(match) == 4:
-            # 年份范围检查
-            num = int(match)
-            if 2020 <= num <= 2030:
-                continue
-
-        filtered.append(match)
-
-    if filtered:
-        return filtered[0]
-
-    return _fallback_extract_hyphenated_verification_code(email_content)
-
-
-def extract_links(email_content: str) -> List[str]:
-    """
-    提取所有 HTTP/HTTPS 链接
-
-    算法：
-    1. 使用正则表达式提取所有链接
-    2. 去重并保持顺序
-    3. 清理链接末尾的标点符号
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        去重后的链接列表
-    """
-    if not email_content:
-        return []
-
-    matches = re.findall(LINK_PATTERN, email_content, re.IGNORECASE)
-
-    # 清理链接（移除末尾的标点符号）
-    cleaned_links = []
-    for link in matches:
-        # 移除末尾的标点符号
-        cleaned = link.rstrip(".,;:!?)>'\"")
-        cleaned_links.append(cleaned)
-
-    # 去重并保持顺序
-    seen = set()
-    unique_links = []
-    for link in cleaned_links:
-        if link not in seen:
-            seen.add(link)
-            unique_links.append(link)
-
-    return unique_links
-
-
-def extract_email_text(email: Dict[str, Any]) -> str:
-    """
-    从邮件对象提取纯文本内容
-
-    优先级：
-    1. body（纯文本）
-    2. body_html（HTML 转纯文本）
-    3. body_preview（预览文本）
-
-    Args:
-        email: 邮件对象字典
-
-    Returns:
-        提取的纯文本内容
-
-    Raises:
-        ValueError: 邮件内容为空
-    """
-    # 优先使用纯文本
-    if email.get("body") and email["body"].strip():
-        return email["body"].strip()
-
-    # 其次使用 HTML 转纯文本
-    if email.get("body_html") and email["body_html"].strip():
-        parser = HTMLTextExtractor()
-        try:
-            parser.feed(email["body_html"])
-            text = parser.get_text()
-            # 解码 HTML 实体
-            text = html.unescape(text)
-            if text.strip():
-                return text.strip()
-        except Exception:
-            pass
-
-    # 再次尝试使用 bodyContent（Graph API 格式）
-    if email.get("bodyContent") and email["bodyContent"].strip():
-        content = email["bodyContent"]
-        # 如果是 HTML，需要转换
-        if email.get("bodyContentType") == "html":
-            parser = HTMLTextExtractor()
-            try:
-                parser.feed(content)
-                text = parser.get_text()
-                text = html.unescape(text)
-                if text.strip():
-                    return text.strip()
-            except Exception:
-                pass
-        else:
-            return content.strip()
-
-    # 最后使用预览文本
-    if email.get("body_preview") and email["body_preview"].strip():
-        return email["body_preview"].strip()
-
-    # 使用 subject 作为补充
-    if email.get("subject") and email["subject"].strip():
-        return email["subject"].strip()
-
-    return ""
-
-
-def extract_verification_info_from_text(email_content: str) -> Dict[str, Any]:
-    """
-    从文本内容提取验证信息
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        包含验证码、链接和格式化输出的字典
-    """
-    # 提取验证码（智能识别 + 保底）
-    verification_code = smart_extract_verification_code(email_content)
-    if not verification_code:
-        verification_code = fallback_extract_verification_code(email_content)
-
-    # 提取链接
-    links = extract_links(email_content)
-
-    # 格式化输出
-    parts = []
-    if verification_code:
-        parts.append(verification_code)
-    parts.extend(links)
-
-    formatted = " ".join(parts) if parts else None
-
-    return {
-        "verification_code": verification_code,
-        "links": links,
-        "formatted": formatted,
-    }
-
-
-def extract_verification_info(email: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    从邮件对象提取验证信息的完整流程
-
-    Args:
-        email: 邮件对象字典
-
-    Returns:
-        包含验证码、链接和格式化输出的字典
-
-    Raises:
-        ValueError: 未找到验证信息
-    """
-    # 提取邮件文本内容
-    email_content = extract_email_text(email)
-
-    if not email_content:
-        raise ValueError("邮件内容为空")
-
-    # 提取验证信息
-    result = extract_verification_info_from_text(email_content)
-
-    if not result["formatted"]:
-        raise ValueError("未找到验证信息")
-
-    return result
-
-
-def _extract_content_text_without_subject(email: Dict[str, Any]) -> str:
-    """
-    仅提取邮件正文/预览（不回退到 subject）。
-
-    注意：extract_email_text() 会在末尾回退 subject；该函数用于 code_source=content 时严格遵循语义。
-    """
-    # 优先使用纯文本
-    if email.get("body") and str(email["body"]).strip():
-        return str(email["body"]).strip()
-
-    # 其次使用 HTML 转纯文本
-    if email.get("body_html") and str(email["body_html"]).strip():
-        parser = HTMLTextExtractor()
-        try:
-            parser.feed(str(email["body_html"]))
-            text = html.unescape(parser.get_text() or "")
-            return text.strip()
-        except Exception:
-            return ""
-
-    # Graph API 格式 bodyContent/bodyContentType
-    if email.get("bodyContent") and str(email["bodyContent"]).strip():
-        content = str(email["bodyContent"])
-        if str(email.get("bodyContentType") or "").lower() == "html":
-            parser = HTMLTextExtractor()
-            try:
-                parser.feed(content)
-                text = html.unescape(parser.get_text() or "")
-                return text.strip()
-            except Exception:
-                return ""
-        return content.strip()
-
-    if email.get("body_preview") and str(email["body_preview"]).strip():
-        return str(email["body_preview"]).strip()
-
-    return ""
-
-
-def _parse_code_length(code_length: str) -> tuple[int, int]:
-    m = re.match(r"^(\d+)-(\d+)$", str(code_length or "").strip())
-    if not m:
-        raise ValueError("code_length 参数无效")
-    min_len = int(m.group(1))
-    max_len = int(m.group(2))
-    if min_len <= 0 or max_len <= 0 or min_len > max_len:
-        raise ValueError("code_length 参数无效")
-    return min_len, max_len
-
-
-def _build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.Pattern:
-    if code_regex:
-        try:
-            return re.compile(code_regex)
-        except re.error as exc:
-            raise ValueError("code_regex 参数无效") from exc
-
-    if code_length:
-        min_len, max_len = _parse_code_length(code_length)
-        return re.compile(rf"\b[A-Za-z0-9]{{{min_len},{max_len}}}\b")
-
-    # 默认：4-8 位数字验证码；字母数字验证码由 group/request 的 code_length 策略启用。
-    return re.compile(r"\b\d{4,8}\b")
-
-
-def _smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern) -> Optional[str]:
-    if not email_content:
-        return None
-
-    content_lower = email_content.lower()
-
-    for keyword in VERIFICATION_KEYWORDS:
-        keyword_lower = keyword.lower()
-        pos = content_lower.find(keyword_lower)
-        if pos == -1:
-            continue
-
-        start = max(0, pos - 50)
-        end = min(len(email_content), pos + len(keyword) + 50)
-        context = email_content[start:end]
-
-        for m in code_re.finditer(context):
-            value = m.group(0)
-            if value and any(c.isdigit() for c in value):
-                return value
-
-    return None
-
-
-def _fallback_extract_code(email_content: str, code_re: re.Pattern) -> Optional[str]:
-    if not email_content:
-        return None
-
-    candidates: List[str] = []
-    for m in code_re.finditer(email_content):
-        value = m.group(0) or ""
-        if not value:
-            continue
-
-        # 与现有提取器保持一致：必须包含至少一个数字
-        if not any(c.isdigit() for c in value):
-            continue
-
-        # 过滤常见误判（仅对纯数字候选生效）
-        if value.isdigit() and len(value) == 4:
-            year = int(value)
-            if 1900 <= year <= 2100:
-                continue
-            hour = int(value[:2])
-            minute = int(value[2:])
-            if 0 <= hour <= 23 and 0 <= minute <= 59:
-                continue
-            num = int(value)
-            if 2020 <= num <= 2030:
-                continue
-
-        candidates.append(value)
-
-    return candidates[0] if candidates else None
-
-
-def _pick_preferred_link(links: List[str], prefer_link_keywords: List[str]) -> Optional[str]:
-    if not links:
-        return None
-
-    keywords = [k.lower() for k in (prefer_link_keywords or []) if k]
-    if keywords:
-        for keyword in keywords:
-            for link in links:
-                if keyword in (link or "").lower():
-                    return link
-
-    return links[0]
-
-
-def extract_verification_info_with_options(
-    email: Dict[str, Any],
-    *,
-    code_regex: str | None = None,
-    code_length: str | None = None,
-    code_source: str = "all",
-    prefer_link_keywords: list[str] | None = None,
-    enforce_mutual_exclusion: bool = True,
-) -> Dict[str, Any]:
-    """
-    在现有提取器基础上支持：
-    - 自定义验证码正则（code_regex）
-    - 自定义验证码长度范围（code_length，如 4-8 / 6-6）
-    - 提取来源限定（subject/content/html/all）
-    - 验证链接关键词优先级（prefer_link_keywords）
-
-    返回结构为兼容扩展字典：
-    - verification_code
-    - verification_link
-    - links
-    - formatted
-    - match_source
-    - confidence          (向后兼容：code/link 中较高者)
-    - code_confidence      (high=关键词命中或调用方指定code_regex命中, low=仅 fallback 或未命中)
-    - link_confidence      (high=链接含验证关键词或邮件正文含强验证语境短语, low=任意首链接且无验证语境)
-
-    注意：该函数主要服务外部 API，不主动抛“未找到验证码/链接”的异常，方便上层按需映射错误码。
-    """
-    subject = str(email.get("subject") or "").strip()
-    content = _extract_content_text_without_subject(email)
-    html_content = str(email.get("body_html") or email.get("html_content") or "").strip()
-
-    source = str(code_source or "all").strip().lower()
-    if source == "subject":
-        source_text = subject
-        match_source = "subject"
-    elif source == "content":
-        source_text = content
-        match_source = "content"
-    elif source == "html":
-        if html_content:
-            parser = HTMLTextExtractor()
-            try:
-                parser.feed(html_content)
-                source_text = html.unescape(parser.get_text() or "").strip()
-            except Exception:
-                source_text = html_content
-        else:
-            source_text = ""
-        match_source = "html"
-    else:
-        # all：content 已含 HTML 转纯文本；勿再拼接原始 HTML，避免 CSS 色值（如 #333333）误判
-        source_text = f"{subject} {content}".strip()
-        match_source = "all"
-
-    code_re = _build_code_regex(code_regex=code_regex, code_length=code_length)
-    # 仅 code_regex 具有判别力，code_length 只是宽度约束，不自动提权
-    caller_directed_code = bool(code_regex)
-
-    # ── 验证码提取 & 置信度 ──
-    verification_code = _smart_extract_code_by_keywords(source_text, code_re)
-    code_confidence: str = "high" if verification_code else "low"
-    if not verification_code:
-        verification_code = _fallback_extract_code(source_text, code_re)
-        # 调用方显式指定了 code_regex（强判别力正则）→ 提取命中即视为可信
-        if verification_code and caller_directed_code:
-            code_confidence = "high"
-    if not verification_code:
-        verification_code = _smart_extract_hyphenated_verification_code(source_text)
-        if verification_code:
-            code_confidence = "high"
-    if not verification_code:
-        verification_code = _fallback_extract_hyphenated_verification_code(source_text)
-        if verification_code:
-            code_confidence = "high"
-
-    # ── 链接提取 & 置信度 ──
-    links = extract_links(f"{subject} {content} {html_content}".strip())
-    prefer_keywords = prefer_link_keywords or DEFAULT_LINK_KEYWORDS
-
-    verification_link = None
-    link_confidence: str = "low"
-    should_pick_link = (not enforce_mutual_exclusion) or (not verification_code)
-    if should_pick_link:
-        verification_link = _pick_preferred_link(links, prefer_keywords)
-        if verification_link:
-            # 优先检查 URL 本身是否含验证关键词
-            for kw in prefer_keywords:
-                if kw and kw.lower() in verification_link.lower():
-                    link_confidence = "high"
-                    break
-            # URL 不含关键词时，检查邮件正文/主题是否有强验证语境短语
-            if link_confidence != "high":
-                full_text_lower = f"{subject} {content}".lower()
-                for phrase in LINK_CONTEXT_PHRASES:
-                    if phrase.lower() in full_text_lower:
-                        link_confidence = "high"
-                        break
-
-    # 总 confidence 向后兼容：取 code / link 中较高者
-    confidence = "high" if code_confidence == "high" or link_confidence == "high" else "low"
-
-    parts: List[str] = []
-    if verification_code:
-        parts.append(verification_code)
-    if verification_link:
-        parts.append(verification_link)
-    formatted = " ".join(parts) if parts else None
-
-    return {
-        "verification_code": verification_code,
-        "verification_link": verification_link,
-        "links": links,
-        "formatted": formatted,
-        "match_source": match_source,
-        "confidence": confidence,
-        "code_confidence": code_confidence,
-        "link_confidence": link_confidence,
-    }
-
-
-def apply_confidence_gate(extracted: Dict[str, Any], *, enforce_mutual_exclusion: bool = True) -> Dict[str, Any]:
-    """
-    对 extract_verification_info_with_options() 的返回结果应用置信度门控。
-
-    规则：
-    - code_confidence != "high"  → verification_code 置 None
-    - link_confidence != "high"  → verification_link 置 None
-    - 重算 formatted 与 confidence 以保持一致
-
-    用途：外部 API 和临时邮箱验证码提取均应调用此函数，
-    确保两条路径使用完全相同的门控标准，避免逻辑漂移。
-
-    Args:
-        extracted: extract_verification_info_with_options() 的返回值（原地修改一份拷贝）
-
-    Returns:
-        门控后的字典（不修改原始 extracted，返回新字典）
-    """
-    result = dict(extracted)
-
-    if result.get("code_confidence") != "high":
-        result["verification_code"] = None
-    if result.get("link_confidence") != "high":
-        result["verification_link"] = None
-
-    # 产品策略：严格互斥（code 优先）
-    if enforce_mutual_exclusion and result.get("verification_code"):
-        result["verification_link"] = None
-        result["link_confidence"] = "low"
-
-    parts = [v for v in (result.get("verification_code"), result.get("verification_link")) if v]
-    result["formatted"] = " ".join(parts) if parts else None
-    result["confidence"] = (
-        "high" if result.get("code_confidence") == "high" or result.get("link_confidence") == "high" else "low"
-    )
-    return result
-
+__all__ = [
+    "CODE_CONTEXT_PHRASES",
+    "DEFAULT_LINK_KEYWORDS",
+    "HYPHENATED_VERIFICATION_PATTERN",
+    "HTMLTextExtractor",
+    "LINK_CONTEXT_PHRASES",
+    "LINK_PATTERN",
+    "VERIFICATION_AI_SCHEMA_VERSION",
+    "VERIFICATION_KEYWORDS",
+    "VERIFICATION_PATTERN",
+    "VerificationInput",
+    "VerificationPolicy",
+    "_build_code_regex",
+    "extract_content_text_without_subject",
+    "_extract_content_text_without_subject",
+    "_fallback_extract_code",
+    "_fallback_extract_hyphenated_verification_code",
+    "_find_hyphenated_code_in_text",
+    "_has_code_context",
+    "_is_valid_hyphenated_code",
+    "_parse_code_length",
+    "_pick_preferred_link",
+    "_smart_extract_code_by_keywords",
+    "_smart_extract_hyphenated_verification_code",
+    "apply_confidence_gate",
+    "build_verification_ai_input_payload",
+    "enhance_verification_with_ai_fallback",
+    "extract_email_text",
+    "extract_links",
+    "extract_verification",
+    "extract_verification_info",
+    "extract_verification_info_from_text",
+    "extract_verification_info_with_options",
+    "fallback_extract_verification_code",
+    "get_verification_ai_runtime_config",
+    "is_verification_ai_config_complete",
+    "probe_verification_ai_runtime",
+    "smart_extract_verification_code",
+]
 
 def get_verification_ai_runtime_config() -> Dict[str, Any]:
     """读取系统级验证码 AI 配置。"""

--- a/outlook_web/services/verification_extractor.py
+++ b/outlook_web/services/verification_extractor.py
@@ -44,6 +44,25 @@ VERIFICATION_KEYWORDS = [
 # 验证码模式（4-8位数字或字母，必须包含至少一个数字）
 VERIFICATION_PATTERN = r"\b[A-Z0-9]{4,8}\b"
 
+# 带连字符的字母数字验证码，例如 x.ai 的 84A-KMN。
+# x.ai HTML 常把验证码紧贴在句末（如 address.84A-KMNIf），因此允许验证码后接英文单词首字母。
+HYPHENATED_VERIFICATION_PATTERN = r"(?<![A-Z0-9])([A-Z0-9]{2,4}-[A-Z0-9]{2,4})(?=$|[^A-Z0-9-]|[A-Z][a-z])"
+
+# 验证码语境提权：出现这些短语时允许识别带连字符验证码，降低订单号/追踪号误判
+CODE_CONTEXT_PHRASES = [
+    "validate your email",
+    "validate your email address",
+    "code below",
+    "xai account",
+    "x.ai",
+    "support@x.ai",
+    "verification code",
+    "confirm your email",
+    "verify your email",
+    "your code",
+    "the code below",
+]
+
 # 链接正则表达式
 LINK_PATTERN = r'https?://[^\s<>"{}|\\^`\[\]]+'
 
@@ -117,6 +136,74 @@ class HTMLTextExtractor(HTMLParser):
         return " ".join(self.text_parts)
 
 
+def _is_valid_hyphenated_code(code: str) -> bool:
+    """校验带连字符验证码：两段字母数字、总长 4-10。
+
+    x.ai 常见两种形态：
+    - 含数字：84A-KMN
+    - 全大写字母：NJF-KUU（无数字，但两段均 >=3 且总长 >=6）
+    """
+    if not code or "-" not in code:
+        return False
+
+    parts = code.split("-")
+    if len(parts) != 2:
+        return False
+    if not all(part.isalnum() for part in parts):
+        return False
+
+    alnum = "".join(parts)
+    if not (4 <= len(alnum) <= 10):
+        return False
+    if any(c.isdigit() for c in alnum):
+        return True
+    # x.ai 全字母验证码（如 NJF-KUU）
+    return len(alnum) >= 6 and all(len(part) >= 3 for part in parts) and alnum.isalpha()
+
+
+def _has_code_context(email_content: str) -> bool:
+    content_lower = email_content.lower()
+    return any(phrase.lower() in content_lower for phrase in CODE_CONTEXT_PHRASES)
+
+
+def _find_hyphenated_code_in_text(text: str) -> Optional[str]:
+    if not text:
+        return None
+
+    for match in re.finditer(HYPHENATED_VERIFICATION_PATTERN, text, re.IGNORECASE):
+        code = match.group(1)
+        if _is_valid_hyphenated_code(code):
+            return code
+    return None
+
+
+def _smart_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    """在验证码关键词附近搜索带连字符验证码。"""
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        code = _find_hyphenated_code_in_text(email_content[start:end])
+        if code:
+            return code
+    return None
+
+
+def _fallback_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    """在验证码语境明确时，从全文搜索带连字符验证码。"""
+    if not email_content or not _has_code_context(email_content):
+        return None
+    return _find_hyphenated_code_in_text(email_content)
+
+
 def smart_extract_verification_code(email_content: str) -> Optional[str]:
     """
     智能提取验证码（基于关键词）
@@ -154,7 +241,11 @@ def smart_extract_verification_code(email_content: str) -> Optional[str]:
                 # 过滤掉纯字母的匹配（验证码通常包含数字）
                 for match in matches:
                     if any(c.isdigit() for c in match):
-                        return match.upper()
+                        return match
+
+    hyphenated_code = _smart_extract_hyphenated_verification_code(email_content)
+    if hyphenated_code:
+        return hyphenated_code
 
     return None
 
@@ -183,8 +274,6 @@ def fallback_extract_verification_code(email_content: str) -> Optional[str]:
     # 过滤规则
     filtered = []
     for match in matches:
-        match_upper = match.upper()
-
         # 必须包含至少一个数字
         if not any(c.isdigit() for c in match):
             continue
@@ -209,9 +298,12 @@ def fallback_extract_verification_code(email_content: str) -> Optional[str]:
             if 2020 <= num <= 2030:
                 continue
 
-        filtered.append(match_upper)
+        filtered.append(match)
 
-    return filtered[0] if filtered else None
+    if filtered:
+        return filtered[0]
+
+    return _fallback_extract_hyphenated_verification_code(email_content)
 
 
 def extract_links(email_content: str) -> List[str]:
@@ -435,9 +527,9 @@ def _build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.
 
     if code_length:
         min_len, max_len = _parse_code_length(code_length)
-        return re.compile(rf"\b\d{{{min_len},{max_len}}}\b")
+        return re.compile(rf"\b[A-Za-z0-9]{{{min_len},{max_len}}}\b")
 
-    # 默认：4-8 位数字验证码（更贴近“验证码”场景）
+    # 默认：4-8 位数字验证码；字母数字验证码由 group/request 的 code_length 策略启用。
     return re.compile(r"\b\d{4,8}\b")
 
 
@@ -460,7 +552,7 @@ def _smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern) -> 
         for m in code_re.finditer(context):
             value = m.group(0)
             if value and any(c.isdigit() for c in value):
-                return value.upper()
+                return value
 
     return None
 
@@ -492,7 +584,7 @@ def _fallback_extract_code(email_content: str, code_re: re.Pattern) -> Optional[
             if 2020 <= num <= 2030:
                 continue
 
-        candidates.append(value.upper())
+        candidates.append(value)
 
     return candidates[0] if candidates else None
 
@@ -551,10 +643,19 @@ def extract_verification_info_with_options(
         source_text = content
         match_source = "content"
     elif source == "html":
-        source_text = html_content
+        if html_content:
+            parser = HTMLTextExtractor()
+            try:
+                parser.feed(html_content)
+                source_text = html.unescape(parser.get_text() or "").strip()
+            except Exception:
+                source_text = html_content
+        else:
+            source_text = ""
         match_source = "html"
     else:
-        source_text = f"{subject} {content} {html_content}".strip()
+        # all：content 已含 HTML 转纯文本；勿再拼接原始 HTML，避免 CSS 色值（如 #333333）误判
+        source_text = f"{subject} {content}".strip()
         match_source = "all"
 
     code_re = _build_code_regex(code_regex=code_regex, code_length=code_length)
@@ -568,6 +669,14 @@ def extract_verification_info_with_options(
         verification_code = _fallback_extract_code(source_text, code_re)
         # 调用方显式指定了 code_regex（强判别力正则）→ 提取命中即视为可信
         if verification_code and caller_directed_code:
+            code_confidence = "high"
+    if not verification_code:
+        verification_code = _smart_extract_hyphenated_verification_code(source_text)
+        if verification_code:
+            code_confidence = "high"
+    if not verification_code:
+        verification_code = _fallback_extract_hyphenated_verification_code(source_text)
+        if verification_code:
             code_confidence = "high"
 
     # ── 链接提取 & 置信度 ──
@@ -1055,7 +1164,7 @@ def enhance_verification_with_ai_fallback(
 
     updated = False
     if ai_code:
-        result["verification_code"] = ai_code.upper()
+        result["verification_code"] = ai_code
         result["code_confidence"] = "high" if ai_confidence == "high" else "low"
         updated = True
     if ai_link:

--- a/static/js/features/groups.js
+++ b/static/js/features/groups.js
@@ -868,7 +868,7 @@
             if (normalizedSource === 'temp' || normalizedSource === 'temp-mail' || normalizedSource === 'temp_mail') {
                 return `/api/temp-emails/${encodeURIComponent(email)}/extract-verification`;
             }
-            return `/api/emails/${encodeURIComponent(email)}/extract-verification`;
+            return `/api/emails/${encodeURIComponent(email)}/verification`;
         }
 
         async function tryFallbackVerificationExtraction(options = {}) {

--- a/static/js/features/mailbox_compact.js
+++ b/static/js/features/mailbox_compact.js
@@ -146,25 +146,12 @@
                 return;
             }
 
-            if (account.latest_verification_code) {
-                try {
-                    await copyToClipboard(account.latest_verification_code);
-                    showToast(
-                        getUiLanguage() === 'en'
-                            ? `Copied: ${account.latest_verification_code}`
-                            : `已复制: ${account.latest_verification_code}`,
-                        'success'
-                    );
-                    return;
-                } catch (error) {
-                    showToast(translateCompactText('复制验证码失败'), 'error');
-                    return;
-                }
+            if (!account.email || !buttonElement || typeof copyVerificationInfo !== 'function') {
+                showToast(translateCompactText('复制验证码失败'), 'error');
+                return;
             }
 
-            if (buttonElement) {
-                copyVerificationInfo(account.email, buttonElement);
-            }
+            return copyVerificationInfo(account.email, buttonElement);
         }
 
         function openCompactSingleTagModal(accountId) {

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -797,6 +797,38 @@ class ExternalApiRegressionTests(ExternalApiBaseTest):
         self.assertTrue(data.get("success"))
         self.assertEqual(data.get("data", {}).get("verification_code"), "123456")
 
+    @patch("outlook_web.services.graph.get_email_detail_graph")
+    @patch("outlook_web.services.graph.get_emails_graph")
+    def test_external_verification_code_matches_internal_unified_verification_api(
+        self, mock_get_emails_graph, mock_get_email_detail_graph
+    ):
+        email_addr = self._insert_outlook_account()
+        self._set_external_api_key("abc123")
+        mock_get_emails_graph.return_value = {
+            "success": True,
+            "emails": [self._graph_email(subject="Your verification code")],
+        }
+        mock_get_email_detail_graph.return_value = self._graph_detail(body_text="Your verification code is Ab12Cd")
+
+        client = self.app.test_client()
+        self._login(client)
+        web_resp = client.get(f"/api/emails/{email_addr}/verification?code_length=6-6")
+        external_resp = client.get(
+            f"/api/external/verification-code?email={email_addr}&code_length=6-6",
+            headers=self._auth_headers(),
+        )
+
+        self.assertEqual(web_resp.status_code, 200)
+        self.assertEqual(external_resp.status_code, 200)
+        web_data = web_resp.get_json() or {}
+        external_data = external_resp.get_json() or {}
+        self.assertEqual(web_data.get("data", {}).get("verification_code"), "Ab12Cd")
+        self.assertEqual(external_data.get("data", {}).get("verification_code"), "Ab12Cd")
+        self.assertEqual(
+            web_data.get("data", {}).get("verification_code"),
+            external_data.get("data", {}).get("verification_code"),
+        )
+
     def test_internal_settings_api_still_returns_existing_fields(self):
         client = self.app.test_client()
         self._login(client)

--- a/tests/test_temp_mail_target_contract.py
+++ b/tests/test_temp_mail_target_contract.py
@@ -452,12 +452,12 @@ if (tempResult !== '/api/temp-emails/demo%2B1%40test.example/extract-verificatio
 }
 
 const normalResult = context.buildVerificationExtractEndpoint('demo+1@test.example', { source: 'outlook' });
-if (normalResult !== '/api/emails/demo%2B1%40test.example/extract-verification') {
+if (normalResult !== '/api/emails/demo%2B1%40test.example/verification') {
   throw new Error(`unexpected normal endpoint: ${normalResult}`);
 }
 
 const defaultResult = context.buildVerificationExtractEndpoint('demo+1@test.example');
-if (defaultResult !== '/api/emails/demo%2B1%40test.example/extract-verification') {
+if (defaultResult !== '/api/emails/demo%2B1%40test.example/verification') {
   throw new Error(`unexpected default endpoint: ${defaultResult}`);
 }
 

--- a/tests/test_v191_compact_mode_api_tdd.py
+++ b/tests/test_v191_compact_mode_api_tdd.py
@@ -317,6 +317,50 @@ class V191CompactModeApiRedTests(unittest.TestCase):
         self.assertEqual(row["latest_verification_folder"], "inbox")
         self.assertEqual(row["latest_verification_received_at"], "2026-03-20T09:58:00Z")
 
+    @patch("outlook_web.controllers.emails.graph_service.get_emails_graph")
+    def test_t_api_005d_fetch_emails_updates_latest_verification_with_mixed_case_code(self, mock_get_emails_graph):
+        client = self.app.test_client()
+        self._login(client)
+        group_id = self._create_group()
+        unique = uuid.uuid4().hex
+        email_addr = f"fetch_mixed_case_{unique}@example.com"
+        account_id = self._create_account(group_id=group_id, email_addr=email_addr)
+
+        mock_get_emails_graph.return_value = {
+            "success": True,
+            "emails": [
+                {
+                    "id": "msg-code",
+                    "subject": "Your verification code",
+                    "from": {"emailAddress": {"address": "security@example.com"}},
+                    "receivedDateTime": "2026-03-20T10:01:00Z",
+                    "bodyPreview": "Your verification code is Ab12Cd. It expires in 10 minutes.",
+                    "isRead": False,
+                    "hasAttachments": False,
+                }
+            ],
+        }
+
+        resp = client.get(f"/api/emails/{email_addr}?folder=inbox&skip=0&top=20")
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json() or {}
+        self.assertEqual(payload.get("success"), True)
+        account_summary = payload.get("account_summary") or {}
+        self.assertEqual(account_summary.get("latest_verification_code"), "Ab12Cd")
+
+        conn = self._db()
+        try:
+            row = conn.execute(
+                "SELECT latest_verification_code FROM accounts WHERE id = ?",
+                (account_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row["latest_verification_code"], "Ab12Cd")
+
     def test_t_api_005b_accounts_api_does_not_fetch_remote_mail_during_list_render(self):
         client = self.app.test_client()
         self._login(client)

--- a/tests/test_v191_compact_mode_api_tdd.py
+++ b/tests/test_v191_compact_mode_api_tdd.py
@@ -361,6 +361,59 @@ class V191CompactModeApiRedTests(unittest.TestCase):
         self.assertIsNotNone(row)
         self.assertEqual(row["latest_verification_code"], "Ab12Cd")
 
+    @patch("outlook_web.controllers.emails.graph_service.get_emails_graph")
+    def test_t_api_005e_fetch_emails_updates_latest_verification_with_group_regex_policy(self, mock_get_emails_graph):
+        client = self.app.test_client()
+        self._login(client)
+        group_id = self._create_group()
+        unique = uuid.uuid4().hex
+        email_addr = f"fetch_regex_policy_{unique}@example.com"
+        account_id = self._create_account(group_id=group_id, email_addr=email_addr)
+
+        conn = self._db()
+        try:
+            conn.execute(
+                "UPDATE groups SET verification_code_length = ?, verification_code_regex = ? WHERE id = ?",
+                ("6-6", r"[A-Z]{2}-\d{4}", group_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        mock_get_emails_graph.return_value = {
+            "success": True,
+            "emails": [
+                {
+                    "id": "msg-policy-code",
+                    "subject": "Your verification code",
+                    "from": {"emailAddress": {"address": "security@example.com"}},
+                    "receivedDateTime": "2026-03-20T10:02:00Z",
+                    "bodyPreview": "Your verification code is AB-1234. It expires in 10 minutes.",
+                    "isRead": False,
+                    "hasAttachments": False,
+                }
+            ],
+        }
+
+        resp = client.get(f"/api/emails/{email_addr}?folder=inbox&skip=0&top=20")
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json() or {}
+        self.assertEqual(payload.get("success"), True)
+        self.assertEqual((payload.get("account_summary") or {}).get("latest_verification_code"), "AB-1234")
+
+        conn = self._db()
+        try:
+            row = conn.execute(
+                "SELECT latest_verification_code FROM accounts WHERE id = ?",
+                (account_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row["latest_verification_code"], "AB-1234")
+
     def test_t_api_005b_accounts_api_does_not_fetch_remote_mail_during_list_render(self):
         client = self.app.test_client()
         self._login(client)

--- a/tests/test_v191_compact_mode_frontend_contract.py
+++ b/tests/test_v191_compact_mode_frontend_contract.py
@@ -125,6 +125,13 @@ class V191CompactModeFrontendContractTests(unittest.TestCase):
         ]:
             self.assertIn(field, compact_js)
 
+    def test_compact_verification_copy_uses_unified_extractor(self):
+        client = self.app.test_client()
+        compact_js = self._get_text(client, "/static/js/features/mailbox_compact.js")
+
+        self.assertIn("return copyVerificationInfo(account.email, buttonElement);", compact_js)
+        self.assertNotIn("copyToClipboard(account.latest_verification_code)", compact_js)
+
     def test_compact_mode_exposes_server_pagination_controls(self):
         client = self.app.test_client()
         compact_js = self._get_text(client, "/static/js/features/mailbox_compact.js")

--- a/tests/test_v191_compact_mode_frontend_contract.py
+++ b/tests/test_v191_compact_mode_frontend_contract.py
@@ -159,6 +159,8 @@ class V191CompactModeFrontendContractTests(unittest.TestCase):
         self.assertIn("verificationCopyInFlight.has(requestKey)", groups_js)
         self.assertIn("syncAccountSummaryToAccountCache", groups_js)
         self.assertIn("syncExtractedVerificationToAccountCache", groups_js)
+        self.assertIn("/api/emails/${encodeURIComponent(email)}/verification", groups_js)
+        self.assertNotIn("/api/emails/${encodeURIComponent(email)}/extract-verification", groups_js)
         self.assertNotIn("let copyVerificationInProgress = false;", groups_js)
 
     def test_compact_action_menu_does_not_restore_extra_copy_menu_items(self):

--- a/tests/test_verification_code_extraction_module.py
+++ b/tests/test_verification_code_extraction_module.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import unittest
+
+from outlook_web.services import verification_code_extraction as core
+from outlook_web.services import verification_extractor as compat
+
+
+class VerificationCodeExtractionModuleTests(unittest.TestCase):
+    def test_unified_module_preserves_mixed_case_and_matches_compat_entrypoint(self):
+        email = {
+            "subject": "Your verification code",
+            "body": "Your verification code is Ab12Cd.",
+            "body_html": "",
+        }
+        policy = core.VerificationPolicy(code_length="6-6", code_source="all")
+
+        module_result = core.extract_verification(core.VerificationInput.from_email(email), policy)
+        compat_result = compat.extract_verification_info_with_options(email, code_length="6-6", code_source="all")
+
+        self.assertEqual(module_result.get("verification_code"), "Ab12Cd")
+        self.assertEqual(module_result.get("verification_code"), compat_result.get("verification_code"))
+        self.assertEqual(module_result.get("code_confidence"), compat_result.get("code_confidence"))
+
+    def test_unified_module_ignores_css_color_and_extracts_context_hyphenated_code(self):
+        email = {
+            "subject": "Validate your email",
+            "body": "",
+            "body_html": (
+                "<html><head><style>.title { color: #333333; }</style></head><body>"
+                "<p>Please use the code below to validate your email address.</p>"
+                "<p>84A-KMN</p>"
+                "</body></html>"
+            ),
+        }
+        result = core.extract_verification(
+            core.VerificationInput.from_email(email),
+            core.VerificationPolicy(code_source="all"),
+        )
+
+        self.assertEqual(result.get("verification_code"), "84A-KMN")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verification_extractor.py
+++ b/tests/test_verification_extractor.py
@@ -413,6 +413,122 @@ class TestVerificationExtractor(unittest.TestCase):
         text = extract_email_text(email)
         self.assertIn("555666", text)
 
+    # ==================== 大小写保持测试（回归） ====================
+
+    def test_smart_extract_preserves_lowercase(self):
+        """
+        测试用例：智能识别 - 保持小写验证码原样
+
+        测试目的：验证智能识别不再私自转换大小写（含数字的小写字母验证码）
+        """
+        content = "Your verification code is ab12cd. Please verify."
+        result = smart_extract_verification_code(content)
+        self.assertEqual(result, "ab12cd")
+
+    def test_smart_extract_preserves_mixed_case(self):
+        """
+        测试用例：智能识别 - 保持大小写混合验证码原样
+        """
+        content = "您的验证码是 Ab12Cd，请尽快使用。"
+        result = smart_extract_verification_code(content)
+        self.assertEqual(result, "Ab12Cd")
+
+    def test_fallback_extract_preserves_lowercase(self):
+        """
+        测试用例：保底提取 - 保持小写验证码原样
+        """
+        content = "Please use ab12cd to complete your registration."
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "ab12cd")
+
+    def test_fallback_extract_preserves_mixed_case(self):
+        """
+        测试用例：保底提取 - 保持大小写混合验证码原样
+        """
+        content = "Please use Ab12Cd to complete your registration."
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "Ab12Cd")
+
+    def test_extract_verification_info_preserves_case(self):
+        """
+        测试用例：完整流程 - verification_code 与 formatted 均保持原大小写
+        """
+        email = {"body": "Your verification code is ab12cd."}
+        result = extract_verification_info_from_text(email["body"])
+        self.assertEqual(result["verification_code"], "ab12cd")
+        self.assertEqual(result["formatted"], "ab12cd")
+
+    # ==================== 带连字符验证码（x.ai）测试 ====================
+
+    def test_smart_extract_xai_hyphenated_code(self):
+        """x.ai 邮件：关键词附近应识别 84A-KMN。"""
+        content = (
+            "Thank you for creating an xAI account. " "Please use the code below to validate your email address.\n\n84A-KMN"
+        )
+        result = smart_extract_verification_code(content)
+        self.assertEqual(result, "84A-KMN")
+
+    def test_fallback_extract_xai_hyphenated_code_with_context(self):
+        """x.ai 邮件：无紧邻关键词时，凭验证码语境应识别 84A-KMN。"""
+        content = (
+            "Validate your email\n"
+            "Thank you for creating an xAI account. "
+            "Please use the code below to validate your email address.\n\n"
+            "84A-KMN\n"
+            "© 2026 X.AI LLC\n"
+            "For questions contact support@x.ai"
+        )
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "84A-KMN")
+
+    def test_hyphenated_code_not_extracted_without_context(self):
+        """无验证码语境时，不应把订单号样式的连字符串当成验证码。"""
+        content = "Your order reference AB-12 has shipped. Tracking ID: XY-99-ZZ."
+        result = fallback_extract_verification_code(content)
+        self.assertIsNone(result)
+
+    def test_fallback_extract_xai_glued_hyphenated_code(self):
+        """x.ai HTML 解析后验证码可能与英文句首粘连（84A-KMNIf）。"""
+        content = (
+            "Thank you for creating an xAI account. "
+            "Please use the code below to validate your email address.84A-KMNIf "
+            "you did not create a new account, please ignore this email."
+        )
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "84A-KMN")
+
+    def test_fallback_extract_xai_all_letter_hyphenated_code(self):
+        """x.ai 真实邮件可能为全字母连字符验证码（如 NJF-KUU）。"""
+        content = (
+            "Thank you for creating an xAI account. "
+            "Please use the code below to validate your email address.\n\n"
+            "NJF-KUU\n\n"
+            "if you did not create a new account, please ignore this email.\n"
+            "SpaceXAI Team\n"
+            "© 2026 X.AI LLC\n"
+            "For questions contact support@x.ai"
+        )
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "NJF-KUU")
+
+    def test_extract_verification_info_xai_email_without_ai(self):
+        """ZER-57 回归：未开启 AI 时也应从 x.ai 邮件提取验证码。"""
+        email = {
+            "subject": "Validate your email",
+            "body": (
+                "Hi,\n\n"
+                "Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.\n\n"
+                "84A-KMN\n\n"
+                "If you did not create a new account, please ignore this email.\n\n"
+                "SpaceXAI Team\n"
+                "© 2026 X.AI LLC\n"
+                "For questions contact support@x.ai"
+            ),
+        }
+        result = extract_verification_info(email)
+        self.assertEqual(result["verification_code"], "84A-KMN")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verification_extractor_options.py
+++ b/tests/test_verification_extractor_options.py
@@ -35,6 +35,32 @@ class VerificationExtractorOptionsTests(unittest.TestCase):
         self.assertEqual(result.get("verification_code"), "654321")
         self.assertIsNone(result.get("verification_link"))
 
+    def test_extract_with_code_length_supports_lowercase_alphanumeric_code(self):
+        func = self._require_new_api()
+        email = {
+            "subject": "Your verification code",
+            "body": "Your verification code is ab12cd",
+            "body_html": "",
+        }
+
+        result = func(email, code_length="6-6")
+
+        self.assertEqual(result.get("verification_code"), "ab12cd")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+    def test_extract_with_code_length_preserves_mixed_case_alphanumeric_code(self):
+        func = self._require_new_api()
+        email = {
+            "subject": "Your verification code",
+            "body": "Your verification code is Ab12Cd",
+            "body_html": "",
+        }
+
+        result = func(email, code_length="6-6")
+
+        self.assertEqual(result.get("verification_code"), "Ab12Cd")
+        self.assertEqual(result.get("code_confidence"), "high")
+
     def test_extract_with_code_regex_supports_alphanumeric_code(self):
         func = self._require_new_api()
         email = {
@@ -510,6 +536,96 @@ class VerificationExtractorConfidenceTests(unittest.TestCase):
             "low",
             "'verify your purchase' 不应触发链接验证语境提权",
         )
+
+    def test_extract_xai_hyphenated_code_without_ai(self):
+        """ZER-57：默认规则路径应识别 x.ai 带连字符验证码，且置信度为 high。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "Validate your email",
+            "body": (
+                "Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.\n\n"
+                "84A-KMN\n\n"
+                "© 2026 X.AI LLC"
+            ),
+            "body_html": "",
+        }
+        result = func(email)
+        self.assertEqual(result.get("verification_code"), "84A-KMN")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+    def test_apply_confidence_gate_keeps_xai_hyphenated_code(self):
+        """门控后 x.ai 带连字符验证码仍应保留。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "Validate your email",
+            "body": "Please use the code below to validate your email address.\n\n84A-KMN",
+            "body_html": "",
+        }
+        extracted = func(email)
+        gated = extractor.apply_confidence_gate(extracted, enforce_mutual_exclusion=False)
+        self.assertEqual(gated.get("verification_code"), "84A-KMN")
+
+    def test_extract_xai_all_letter_hyphenated_code_njf_kuu(self):
+        """ZER-57 真实收信样本：全字母验证码 NJF-KUU。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "xAI confirmation",
+            "body": (
+                "Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.\n\n"
+                "NJF-KUU\n\n"
+                "if you did not create a new account, please ignore this email.\n"
+                "SpaceXAI Team\n"
+                "© 2026 X.AI LLC\n"
+                "For questions contact support@x.ai"
+            ),
+            "body_html": "",
+        }
+        result = func(email)
+        self.assertEqual(result.get("verification_code"), "NJF-KUU")
+        self.assertEqual(result.get("code_confidence"), "high")
+        gated = extractor.apply_confidence_gate(result, enforce_mutual_exclusion=False)
+        self.assertEqual(gated.get("verification_code"), "NJF-KUU")
+
+    def test_extract_xai_html_with_css_color_false_positive(self):
+        """x.ai HTML 邮件含 #333333 样式色值时，不应误提取为验证码。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "NJF-KUU xAI confirmation code",
+            "body": "",
+            "body_html": (
+                "<html><head><style>.title { color: #333333; }</style></head><body>"
+                "<p>Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.</p>"
+                "<p>NJF-KUU</p>"
+                "<p>For questions contact support@x.ai</p>"
+                "</body></html>"
+            ),
+        }
+        result = func(email, code_source="all")
+        self.assertEqual(result.get("verification_code"), "NJF-KUU")
+        self.assertEqual(result.get("code_confidence"), "high")
+        gated = extractor.apply_confidence_gate(result, enforce_mutual_exclusion=False)
+        self.assertEqual(gated.get("verification_code"), "NJF-KUU")
+
+    def test_extract_html_ignores_css_color_and_keeps_context_hyphen_code(self):
+        """ZER-90: HTML 样式色值 #333333 不应覆盖正文里的 84A-KMN。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "Verification",
+            "body": "",
+            "body_html": (
+                "<html><head><style>.title { color: #333333; }</style></head><body>"
+                "<p>Your verification code is 84A-KMN</p>"
+                "</body></html>"
+            ),
+        }
+
+        result = func(email, code_source="all")
+
+        self.assertEqual(result.get("verification_code"), "84A-KMN")
+        self.assertEqual(result.get("code_confidence"), "high")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes Linear ZER-90 by unifying the compact-mode verification extraction path with the standard extraction flow.

- Support alphanumeric codes when `code_length` is explicitly resolved, while keeping the default extractor numeric-only to avoid URL/promo-code false positives.
- Preserve original case for alphanumeric and hyphenated verification codes.
- Avoid raw HTML/CSS color false positives such as `#333333`, while still extracting contextual hyphenated codes like `84A-KMN`.
- Route compact summary cache extraction through `extract_verification_info_with_options()` plus confidence gating, and make compact copy call the unified `copyVerificationInfo()` path instead of copying stale cache values.

## Verification

- `.venv/bin/python -m pytest tests/test_verification_extractor.py tests/test_verification_extractor_options.py tests/test_v191_compact_mode_frontend_contract.py tests/test_v191_compact_mode_api_tdd.py` -> 112 passed
- `.venv/bin/python -m pytest` -> 1563 passed, 7 skipped

## Issue Link

- Linear: ZER-90
- This PR is the implementation PR for ZER-90.