### PR TITLE
feat(verification): 统一验证码提取模块与前端接口 (ZER-90)

### DIFF
--- a/outlook_web/controllers/emails.py
+++ b/outlook_web/controllers/emails.py
@@ -35,6 +35,23 @@ _EXTERNAL_NESTED_UPSTREAM_CODES = {
     "IMAP_CONNECT_FAILED",
     "IMAP_FOLDER_NOT_FOUND",
 }
+_VERIFICATION_REQUEST_FIELDS = {"code", "link", "any"}
+
+
+def _expected_field_for_verification_request(field: str) -> str | None:
+    if field == "code":
+        return "verification_code"
+    if field == "link":
+        return "verification_link"
+    return None
+
+
+def _has_requested_verification_result(data: Dict[str, Any], expected_field: str | None) -> bool:
+    if expected_field:
+        return bool((data or {}).get(expected_field))
+    return bool(
+        (data or {}).get("formatted") or (data or {}).get("verification_code") or (data or {}).get("verification_link")
+    )
 
 
 def _build_response_from_error_payload(error_payload: dict[str, Any]):
@@ -954,13 +971,14 @@ def _api_extract_verification_impl(email_addr: str) -> Any:
         )
 
     field = (request.args.get("field") or "any").strip().lower()
-    if field not in {"code", "link", "any"}:
+    if field not in _VERIFICATION_REQUEST_FIELDS:
         return build_error_response(
             "INVALID_PARAM",
             "field 参数无效",
             message_en="Invalid field parameter",
             status=400,
         )
+    expected_field = _expected_field_for_verification_request(field)
 
     account_type = (account.get("account_type") or "outlook").strip().lower()
     if account_type != "imap":
@@ -979,8 +997,9 @@ def _api_extract_verification_impl(email_addr: str) -> Any:
             code_regex=request_code_regex,
             code_length=request_code_length,
             code_source=code_source,
+            expected_field=expected_field,
         )
-        if not data.get("formatted") and not data.get("verification_code") and not data.get("verification_link"):
+        if not _has_requested_verification_result(data, expected_field):
             raise external_api_service.MailNotFoundError("未找到验证信息", data={"email": email_addr})
 
         if field == "code":

--- a/outlook_web/controllers/emails.py
+++ b/outlook_web/controllers/emails.py
@@ -899,6 +899,16 @@ def api_get_email_detail(email_addr: str, message_id: str) -> Any:
 
 @login_required
 def api_extract_verification(email_addr: str) -> Any:
+    return _api_extract_verification_impl(email_addr)
+
+
+@login_required
+def api_get_verification(email_addr: str) -> Any:
+    """ZER-90：前端统一验证码提取接口（与 extract-verification 等价，支持 field 参数）。"""
+    return _api_extract_verification_impl(email_addr)
+
+
+def _api_extract_verification_impl(email_addr: str) -> Any:
     """
     提取验证码和链接接口
 
@@ -909,6 +919,12 @@ def api_extract_verification(email_addr: str) -> Any:
     2. Graph API (junkemail) - 从垃圾邮件获取
     3. IMAP (新服务器) - Graph API 失败时回退
     4. IMAP (旧服务器) - 最后的回退方案
+
+    统一接口参数（/verification 与 /extract-verification 均支持）：
+    - field=code|link|any
+    - code_source=subject|content|html|all
+    - code_length / code_regex
+    - refresh=1（保留参数，当前每次均实时拉取）
     """
     _t0 = time.monotonic()
     _LOGGER.debug("[PERF] extract_verification | 开始 | email=%s", email_addr)
@@ -937,6 +953,15 @@ def api_extract_verification(email_addr: str) -> Any:
             status=400,
         )
 
+    field = (request.args.get("field") or "any").strip().lower()
+    if field not in {"code", "link", "any"}:
+        return build_error_response(
+            "INVALID_PARAM",
+            "field 参数无效",
+            message_en="Invalid field parameter",
+            status=400,
+        )
+
     account_type = (account.get("account_type") or "outlook").strip().lower()
     if account_type != "imap":
         decrypt_error_response = _build_account_credential_decrypt_failed_response(account)
@@ -957,6 +982,13 @@ def api_extract_verification(email_addr: str) -> Any:
         )
         if not data.get("formatted") and not data.get("verification_code") and not data.get("verification_link"):
             raise external_api_service.MailNotFoundError("未找到验证信息", data={"email": email_addr})
+
+        if field == "code":
+            data["verification_link"] = None
+            data["formatted"] = data.get("verification_code") or None
+        elif field == "link":
+            data["verification_code"] = None
+            data["formatted"] = data.get("verification_link") or None
 
         account_summary = _update_account_summary_from_verification(account, data)
         _LOGGER.debug(

--- a/outlook_web/controllers/temp_emails.py
+++ b/outlook_web/controllers/temp_emails.py
@@ -227,6 +227,15 @@ def api_get_temp_email_message_detail(email_addr: str, message_id: str) -> Any:
 
 @login_required
 def api_extract_temp_email_verification(email_addr: str) -> Any:
+    return _api_extract_temp_email_verification_impl(email_addr)
+
+
+@login_required
+def api_get_temp_email_verification(email_addr: str) -> Any:
+    return _api_extract_temp_email_verification_impl(email_addr)
+
+
+def _api_extract_temp_email_verification_impl(email_addr: str) -> Any:
     try:
         result = temp_mail_service.extract_verification(email_addr)
         return jsonify({"success": True, "data": result, "message": "提取成功"})

--- a/outlook_web/controllers/temp_emails.py
+++ b/outlook_web/controllers/temp_emails.py
@@ -31,6 +31,18 @@ def _parse_bool_flag(value: Any, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
+_TEMP_VERIFICATION_CODE_SOURCES = {"subject", "content", "html", "all"}
+_TEMP_VERIFICATION_FIELDS = {"code", "link", "any"}
+
+
+def _expected_field_for_temp_verification_request(field: str) -> str | None:
+    if field == "code":
+        return "verification_code"
+    if field == "link":
+        return "verification_link"
+    return None
+
+
 # ==================== 临时邮箱 API ====================
 
 
@@ -236,8 +248,35 @@ def api_get_temp_email_verification(email_addr: str) -> Any:
 
 
 def _api_extract_temp_email_verification_impl(email_addr: str) -> Any:
+    request_code_length = (request.args.get("code_length") or "").strip() or None
+    request_code_regex = (request.args.get("code_regex") or "").strip() or None
+    code_source = (request.args.get("code_source") or "all").strip().lower()
+    if code_source not in _TEMP_VERIFICATION_CODE_SOURCES:
+        return build_error_response(
+            "INVALID_PARAM",
+            "参数错误",
+            status=400,
+            message_en="Invalid parameters",
+        )
+
+    field = (request.args.get("field") or "any").strip().lower()
+    if field not in _TEMP_VERIFICATION_FIELDS:
+        return build_error_response(
+            "INVALID_PARAM",
+            "field 参数无效",
+            status=400,
+            message_en="Invalid field parameter",
+        )
+    expected_field = _expected_field_for_temp_verification_request(field)
+
     try:
-        result = temp_mail_service.extract_verification(email_addr)
+        result = temp_mail_service.extract_verification(
+            email_addr,
+            code_regex=request_code_regex,
+            code_length=request_code_length,
+            code_source=code_source,
+            expected_field=expected_field,
+        )
         return jsonify({"success": True, "data": result, "message": "提取成功"})
     except TempMailError as exc:
         message_en = "Verification info not found" if exc.status == 404 else "Failed to extract verification info"

--- a/outlook_web/routes/emails.py
+++ b/outlook_web/routes/emails.py
@@ -27,6 +27,11 @@ def create_blueprint() -> Blueprint:
         methods=["GET"],
     )
     bp.add_url_rule(
+        "/api/emails/<email_addr>/verification",
+        view_func=emails_controller.api_get_verification,
+        methods=["GET"],
+    )
+    bp.add_url_rule(
         "/api/emails/delete",
         view_func=emails_controller.api_delete_emails,
         methods=["POST"],

--- a/outlook_web/routes/temp_emails.py
+++ b/outlook_web/routes/temp_emails.py
@@ -28,6 +28,11 @@ def create_blueprint(csrf_exempt=None) -> Blueprint:
             ["GET"],
         ),
         (
+            "/api/temp-emails/<path:email_addr>/verification",
+            temp_emails_controller.api_get_temp_email_verification,
+            ["GET"],
+        ),
+        (
             "/api/temp-emails/<path:email_addr>",
             temp_emails_controller.api_delete_temp_email,
             ["DELETE"],

--- a/outlook_web/services/account_compact_summary.py
+++ b/outlook_web/services/account_compact_summary.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional
 
 from outlook_web.repositories import accounts as accounts_repo
-from outlook_web.services.verification_extractor import extract_verification_info
+from outlook_web.services.verification_extractor import apply_confidence_gate, extract_verification_info_with_options
 
 COMPACT_SUMMARY_FIELDS = (
     "latest_email_subject",
@@ -90,11 +90,13 @@ def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]]) -> Opt
 
         candidate_payload = {
             "subject": str(message.get("subject") or ""),
+            "body": str(message.get("body_preview") or ""),
             "body_preview": str(message.get("body_preview") or ""),
         }
 
         try:
-            result = extract_verification_info(candidate_payload)
+            result = extract_verification_info_with_options(candidate_payload, code_source="all", code_length="6-6")
+            result = apply_confidence_gate(result, enforce_mutual_exclusion=False)
         except ValueError:
             continue
 

--- a/outlook_web/services/account_compact_summary.py
+++ b/outlook_web/services/account_compact_summary.py
@@ -4,7 +4,13 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional
 
 from outlook_web.repositories import accounts as accounts_repo
-from outlook_web.services.verification_extractor import apply_confidence_gate, extract_verification_info_with_options
+from outlook_web.repositories import groups as groups_repo
+from outlook_web.services.verification_code_extraction import (
+    VerificationInput,
+    apply_confidence_gate,
+    extract_verification,
+    policy_from_resolved,
+)
 
 COMPACT_SUMMARY_FIELDS = (
     "latest_email_subject",
@@ -81,24 +87,49 @@ def _pick_latest_message(messages: Iterable[Dict[str, Any]]) -> Optional[Dict[st
     return max(normalized, key=lambda item: parse_received_at(item.get("received_at")))
 
 
-def _pick_latest_verification_message(messages: Iterable[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+def _resolve_compact_verification_policy(account_id: int):
+    account = accounts_repo.get_account_by_id(account_id)
+    group = None
+    if account and account.get("group_id"):
+        try:
+            group_id = int(account.get("group_id"))
+        except (TypeError, ValueError):
+            group_id = 0
+        if group_id > 0:
+            group = groups_repo.get_group_by_id(group_id)
+
+    resolved = groups_repo.resolve_group_verification_policy(
+        group=group,
+        default_code_length="6-6",
+        apply_default=True,
+    )
+    return policy_from_resolved(
+        resolved,
+        code_source="all",
+        enforce_mutual_exclusion=False,
+        apply_confidence_gate=True,
+    )
+
+
+def _pick_latest_verification_message(
+    messages: Iterable[Dict[str, Any]],
+    *,
+    verification_policy,
+) -> Optional[Dict[str, str]]:
     latest_match: Optional[Dict[str, str]] = None
 
     for message in messages:
         if not message:
             continue
 
-        candidate_payload = {
-            "subject": str(message.get("subject") or ""),
-            "body": str(message.get("body_preview") or ""),
-            "body_preview": str(message.get("body_preview") or ""),
-        }
+        candidate_payload = VerificationInput(
+            subject=str(message.get("subject") or ""),
+            body=str(message.get("body_preview") or ""),
+            body_preview=str(message.get("body_preview") or ""),
+        )
 
-        try:
-            result = extract_verification_info_with_options(candidate_payload, code_source="all", code_length="6-6")
-            result = apply_confidence_gate(result, enforce_mutual_exclusion=False)
-        except ValueError:
-            continue
+        result = extract_verification(candidate_payload, verification_policy)
+        result = apply_confidence_gate(result, enforce_mutual_exclusion=False)
 
         verification_code = str(result.get("verification_code") or "").strip()
         if not verification_code:
@@ -170,8 +201,9 @@ def update_summary_from_message_list(
 ) -> Dict[str, str]:
     current = accounts_repo.get_account_compact_summary(account_id) or empty_compact_summary()
     normalized_messages = [normalize_message_summary(message, folder=folder) for message in messages or []]
+    verification_policy = _resolve_compact_verification_policy(account_id)
     latest = _pick_latest_message(normalized_messages)
-    latest_verification = _pick_latest_verification_message(normalized_messages)
+    latest_verification = _pick_latest_verification_message(normalized_messages, verification_policy=verification_policy)
     updated = _merge_latest_email(current, latest)
     if latest_verification:
         updated = _merge_latest_verification(

--- a/outlook_web/services/temp_mail_service.py
+++ b/outlook_web/services/temp_mail_service.py
@@ -38,6 +38,35 @@ class TempMailError(Exception):
         self.data = data
 
 
+def _shape_verification_result_by_expected_field(
+    extracted: dict[str, Any],
+    expected_field: str | None,
+) -> dict[str, Any]:
+    if expected_field not in {"verification_code", "verification_link"}:
+        return extracted
+
+    result = dict(extracted or {})
+    if expected_field == "verification_code":
+        result["verification_link"] = None
+        result["link_confidence"] = "low"
+    else:
+        result["verification_code"] = None
+        result["code_confidence"] = "low"
+
+    parts = [v for v in (result.get("verification_code"), result.get("verification_link")) if v]
+    result["formatted"] = " ".join(parts) if parts else None
+    result["confidence"] = (
+        "high" if result.get("code_confidence") == "high" or result.get("link_confidence") == "high" else "low"
+    )
+    return result
+
+
+def _build_expected_field_not_found_error(expected_field: str) -> TempMailError:
+    if expected_field == "verification_code":
+        return TempMailError("VERIFICATION_CODE_NOT_FOUND", "未找到验证码", status=404)
+    return TempMailError("VERIFICATION_LINK_NOT_FOUND", "未找到验证链接", status=404)
+
+
 def _utc_iso_from_timestamp(value: Any, fallback: str = "") -> str:
     try:
         timestamp = int(value or 0)
@@ -587,6 +616,7 @@ class TempMailService:
         code_regex: str | None = None,
         code_length: str | None = None,
         code_source: str = "all",
+        expected_field: str | None = None,
     ) -> dict[str, Any]:
         # 临时邮箱验证码提取入口，结构与 external_api.get_verification_result 对齐，共享日志埋点
         started_at = time.time()
@@ -642,6 +672,11 @@ class TempMailService:
             extracted["subject"] = detail.get("subject") or latest.get("subject") or ""
             extracted["received_at"] = detail.get("created_at") or latest.get("created_at") or ""
             extracted["email"] = email_addr
+            extracted = _shape_verification_result_by_expected_field(extracted, expected_field)
+            if expected_field and not extracted.get(expected_field):
+                error = _build_expected_field_not_found_error(expected_field)
+                error.data = extracted
+                raise error
             if not extracted.get("verification_code") and not extracted.get("verification_link"):
                 raise TempMailError(
                     "VERIFICATION_CODE_NOT_FOUND",

--- a/outlook_web/services/verification_channel_routing.py
+++ b/outlook_web/services/verification_channel_routing.py
@@ -402,85 +402,86 @@ def extract_verification_for_outlook(
         if not emails:
             continue
 
-        latest = sorted(
+        sorted_emails = sorted(
             emails,
             key=lambda x: x.get("date", "") or x.get("receivedDateTime", ""),
             reverse=True,
-        )[0]
+        )
 
-        if channel.startswith("imap_"):
-            detail = channel_result.get("detail")
-        else:
-            detail = fetch_email_detail_for_channel(
-                account=account,
-                channel=channel,
-                message_id=latest.get("id", ""),
-                proxy_url=proxy_url,
+        for index, latest in enumerate(sorted_emails):
+            if channel.startswith("imap_") and index == 0 and channel_result.get("detail"):
+                detail = channel_result.get("detail")
+            else:
+                detail = fetch_email_detail_for_channel(
+                    account=account,
+                    channel=channel,
+                    message_id=latest.get("id", ""),
+                    proxy_url=proxy_url,
+                )
+
+            if not detail:
+                continue
+
+            verification_attempted = True
+
+            email_obj = _build_email_obj_from_channel_detail(detail=detail, latest=latest)
+
+            from outlook_web.services.verification_extractor import (
+                apply_confidence_gate,
+                enhance_verification_with_ai_fallback,
+                extract_verification_info_with_options,
             )
 
-        if not detail:
-            continue
+            extracted = extract_verification_info_with_options(
+                email_obj,
+                code_regex=resolved_policy.get("code_regex"),
+                code_length=resolved_policy.get("code_length"),
+                code_source=code_source,
+                enforce_mutual_exclusion=False,
+            )
+            extracted = enhance_verification_with_ai_fallback(
+                email=email_obj,
+                extracted=extracted,
+                code_regex=resolved_policy.get("code_regex"),
+                code_length=resolved_policy.get("code_length"),
+                code_source=code_source,
+                enforce_mutual_exclusion=False,
+            )
+            extracted = apply_confidence_gate(extracted, enforce_mutual_exclusion=False)
 
-        verification_attempted = True
+            extracted.update(
+                {
+                    "email": account.get("email", ""),
+                    "matched_email_id": latest.get("id", ""),
+                    "from": email_obj["from"],
+                    "subject": email_obj["subject"],
+                    "received_at": email_obj["date"],
+                    "folder": latest.get("folder", "inbox"),
+                    "method": _get_channel_display_name(channel),
+                }
+            )
+            extracted["_log_channel"] = (
+                "ai_fallback" if extracted.get("_used_ai") and _is_extraction_success(extracted, expected_field) else channel
+            )
+            extracted["_log_used_ai"] = bool(extracted.get("_used_ai"))
+            last_extracted = extracted
 
-        email_obj = _build_email_obj_from_channel_detail(detail=detail, latest=latest)
+            if _is_extraction_success(extracted, expected_field):
+                try:
+                    from outlook_web.repositories import accounts as accounts_repo
 
-        from outlook_web.services.verification_extractor import (
-            apply_confidence_gate,
-            enhance_verification_with_ai_fallback,
-            extract_verification_info_with_options,
-        )
+                    accounts_repo.update_preferred_verification_channel(int(account["id"]), channel)
+                except Exception:
+                    pass
 
-        extracted = extract_verification_info_with_options(
-            email_obj,
-            code_regex=resolved_policy.get("code_regex"),
-            code_length=resolved_policy.get("code_length"),
-            code_source=code_source,
-            enforce_mutual_exclusion=False,
-        )
-        extracted = enhance_verification_with_ai_fallback(
-            email=email_obj,
-            extracted=extracted,
-            code_regex=resolved_policy.get("code_regex"),
-            code_length=resolved_policy.get("code_length"),
-            code_source=code_source,
-            enforce_mutual_exclusion=False,
-        )
-        extracted = apply_confidence_gate(extracted, enforce_mutual_exclusion=False)
-
-        extracted.update(
-            {
-                "email": account.get("email", ""),
-                "matched_email_id": latest.get("id", ""),
-                "from": email_obj["from"],
-                "subject": email_obj["subject"],
-                "received_at": email_obj["date"],
-                "folder": latest.get("folder", "inbox"),
-                "method": _get_channel_display_name(channel),
-            }
-        )
-        extracted["_log_channel"] = (
-            "ai_fallback" if extracted.get("_used_ai") and _is_extraction_success(extracted, expected_field) else channel
-        )
-        extracted["_log_used_ai"] = bool(extracted.get("_used_ai"))
-        last_extracted = extracted
-
-        if _is_extraction_success(extracted, expected_field):
-            try:
-                from outlook_web.repositories import accounts as accounts_repo
-
-                accounts_repo.update_preferred_verification_channel(int(account["id"]), channel)
-            except Exception:
-                pass
-
-            return {
-                "success": True,
-                "data": extracted,
-                "channel_used": channel,
-                "_log_channel": extracted.get("_log_channel") or channel,
-                "_log_used_ai": bool(extracted.get("_used_ai")),
-                "new_refresh_token": new_refresh_token,
-            }
+                return {
+                    "success": True,
+                    "data": extracted,
+                    "channel_used": channel,
+                    "_log_channel": extracted.get("_log_channel") or channel,
+                    "_log_used_ai": bool(extracted.get("_used_ai")),
+                    "new_refresh_token": new_refresh_token,
+                }
 
     if not any_channel_read_success:
         return {

--- a/outlook_web/services/verification_code_extraction.py
+++ b/outlook_web/services/verification_code_extraction.py
@@ -1,0 +1,598 @@
+"""
+统一验证码提取模块（ZER-90）
+
+将验证码候选生成、评分、门控收敛为单一服务，供 Web API、External API、
+简洁模式摘要及旧版 verification_extractor 兼容层共用。
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Any, Dict, List, Optional
+
+# 验证码关键词列表（支持中英文）
+VERIFICATION_KEYWORDS = [
+    "验证码",
+    "code",
+    "验证",
+    "verification",
+    "OTP",
+    "动态码",
+    "校验码",
+    "verify code",
+    "confirmation code",
+    "security code",
+    "验证码是",
+    "your code",
+    "code is",
+    "激活码",
+    "短信验证码",
+]
+
+VERIFICATION_PATTERN = r"\b[A-Z0-9]{4,8}\b"
+
+# 带连字符字母数字验证码，例如 x.ai 的 84A-KMN
+HYPHENATED_VERIFICATION_PATTERN = r"(?<![A-Z0-9])([A-Z0-9]{2,4}-[A-Z0-9]{2,4})(?=$|[^A-Z0-9-]|[A-Z][a-z])"
+
+CODE_CONTEXT_PHRASES = [
+    "validate your email",
+    "validate your email address",
+    "code below",
+    "xai account",
+    "x.ai",
+    "support@x.ai",
+    "verification code",
+    "confirm your email",
+    "verify your email",
+    "your code",
+    "the code below",
+]
+
+LINK_PATTERN = r'https?://[^\s<>"{}|\\^`\[\]]+'
+
+DEFAULT_LINK_KEYWORDS = [
+    "verify",
+    "confirmation",
+    "confirm",
+    "activate",
+    "validation",
+]
+
+LINK_CONTEXT_PHRASES = [
+    "verify your email",
+    "verify your account",
+    "verify your address",
+    "confirm your email",
+    "confirm your account",
+    "confirm your address",
+    "activate your email",
+    "activate your account",
+    "email verification",
+    "account verification",
+    "验证您的邮箱",
+    "验证你的邮箱",
+    "验证您的账户",
+    "验证你的账户",
+    "验证您的账号",
+    "验证你的账号",
+    "确认您的邮箱",
+    "确认你的邮箱",
+    "确认您的账户",
+    "确认你的账户",
+    "激活您的账户",
+    "激活你的账户",
+    "激活您的邮箱",
+    "激活你的邮箱",
+    "邮箱验证",
+    "账号验证",
+    "账户验证",
+]
+
+
+@dataclass
+class VerificationPolicy:
+    """验证码提取策略。"""
+
+    code_regex: str | None = None
+    code_length: str | None = None
+    code_source: str = "all"
+    prefer_link_keywords: List[str] = field(default_factory=lambda: list(DEFAULT_LINK_KEYWORDS))
+    enforce_mutual_exclusion: bool = True
+    apply_confidence_gate: bool = False
+    expected_field: str | None = None  # code | link | any
+
+
+@dataclass
+class VerificationInput:
+    """统一邮件输入：subject / 正文 / HTML 分离，避免直接扫描原始 HTML 样式。"""
+
+    subject: str = ""
+    body: str = ""
+    body_preview: str = ""
+    body_html: str = ""
+    html_content: str = ""
+    body_content: str = ""
+    body_content_type: str = ""
+
+    @classmethod
+    def from_email_dict(cls, email: Dict[str, Any]) -> VerificationInput:
+        payload = email or {}
+        return cls(
+            subject=str(payload.get("subject") or "").strip(),
+            body=str(payload.get("body") or "").strip(),
+            body_preview=str(payload.get("body_preview") or "").strip(),
+            body_html=str(payload.get("body_html") or payload.get("html_content") or "").strip(),
+            html_content=str(payload.get("html_content") or "").strip(),
+            body_content=str(payload.get("bodyContent") or "").strip(),
+            body_content_type=str(payload.get("bodyContentType") or "").strip(),
+        )
+
+    def as_legacy_email_dict(self) -> Dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "body": self.body,
+            "body_preview": self.body_preview,
+            "body_html": self.body_html or self.html_content,
+            "html_content": self.html_content,
+            "bodyContent": self.body_content,
+            "bodyContentType": self.body_content_type,
+        }
+
+
+class HTMLTextExtractor(HTMLParser):
+    """HTML 转纯文本提取器（跳过 style/script 等不可见节点）。"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.text_parts: List[str] = []
+        self._skip_tags = {"style", "script", "head", "meta", "link"}
+        self._current_skip = False
+
+    def handle_starttag(self, tag: str, attrs: Any) -> None:
+        if tag.lower() in self._skip_tags:
+            self._current_skip = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() in self._skip_tags:
+            self._current_skip = False
+
+    def handle_data(self, data: str) -> None:
+        if not self._current_skip and data.strip():
+            self.text_parts.append(data.strip())
+
+    def get_text(self) -> str:
+        return " ".join(self.text_parts)
+
+
+def html_to_visible_text(html_content: str) -> str:
+    if not html_content:
+        return ""
+    parser = HTMLTextExtractor()
+    try:
+        parser.feed(html_content)
+        return html.unescape(parser.get_text() or "").strip()
+    except Exception:
+        return html_content.strip()
+
+
+def extract_content_text_without_subject(email_input: VerificationInput) -> str:
+    if email_input.body:
+        return email_input.body
+
+    html_raw = email_input.body_html or email_input.html_content
+    if html_raw:
+        return html_to_visible_text(html_raw)
+
+    if email_input.body_content:
+        if email_input.body_content_type.lower() == "html":
+            return html_to_visible_text(email_input.body_content)
+        return email_input.body_content
+
+    if email_input.body_preview:
+        return email_input.body_preview
+
+    return ""
+
+
+def extract_email_text(email: Dict[str, Any]) -> str:
+    email_input = VerificationInput.from_email_dict(email)
+    content = extract_content_text_without_subject(email_input)
+    if content:
+        return content
+    if email_input.subject:
+        return email_input.subject
+    return ""
+
+
+def _parse_code_length(code_length: str) -> tuple[int, int]:
+    m = re.match(r"^(\d+)-(\d+)$", str(code_length or "").strip())
+    if not m:
+        raise ValueError("code_length 参数无效")
+    min_len = int(m.group(1))
+    max_len = int(m.group(2))
+    if min_len <= 0 or max_len <= 0 or min_len > max_len:
+        raise ValueError("code_length 参数无效")
+    return min_len, max_len
+
+
+def build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.Pattern[str]:
+    if code_regex:
+        try:
+            return re.compile(code_regex)
+        except re.error as exc:
+            raise ValueError("code_regex 参数无效") from exc
+
+    if code_length:
+        min_len, max_len = _parse_code_length(code_length)
+        return re.compile(rf"\b[A-Za-z0-9]{{{min_len},{max_len}}}\b")
+
+    return re.compile(r"\b\d{4,8}\b")
+
+
+def _is_valid_hyphenated_code(code: str) -> bool:
+    if not code or "-" not in code:
+        return False
+
+    parts = code.split("-")
+    if len(parts) != 2:
+        return False
+    if not all(part.isalnum() for part in parts):
+        return False
+
+    alnum = "".join(parts)
+    if not (4 <= len(alnum) <= 10):
+        return False
+    if any(c.isdigit() for c in alnum):
+        return True
+    return len(alnum) >= 6 and all(len(part) >= 3 for part in parts) and alnum.isalpha()
+
+
+def _has_code_context(email_content: str) -> bool:
+    content_lower = email_content.lower()
+    return any(phrase.lower() in content_lower for phrase in CODE_CONTEXT_PHRASES)
+
+
+def _find_hyphenated_code_in_text(text: str) -> Optional[str]:
+    if not text:
+        return None
+
+    for match in re.finditer(HYPHENATED_VERIFICATION_PATTERN, text, re.IGNORECASE):
+        code = match.group(1)
+        if _is_valid_hyphenated_code(code):
+            return code
+    return None
+
+
+def smart_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        code = _find_hyphenated_code_in_text(email_content[start:end])
+        if code:
+            return code
+    return None
+
+
+def fallback_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    if not email_content or not _has_code_context(email_content):
+        return None
+    return _find_hyphenated_code_in_text(email_content)
+
+
+def smart_extract_verification_code(email_content: str) -> Optional[str]:
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        context = email_content[start:end]
+        matches = re.findall(VERIFICATION_PATTERN, context, re.IGNORECASE)
+        for match in matches:
+            if any(c.isdigit() for c in match):
+                return match
+
+    return smart_extract_hyphenated_verification_code(email_content)
+
+
+def fallback_extract_verification_code(email_content: str) -> Optional[str]:
+    if not email_content:
+        return None
+
+    filtered: List[str] = []
+    for match in re.findall(VERIFICATION_PATTERN, email_content, re.IGNORECASE):
+        if not any(c.isdigit() for c in match):
+            continue
+
+        if match.isdigit() and len(match) == 4:
+            year = int(match)
+            if 1900 <= year <= 2100:
+                continue
+            hour = int(match[:2])
+            minute = int(match[2:])
+            if 0 <= hour <= 23 and 0 <= minute <= 59:
+                continue
+            if 2020 <= year <= 2030:
+                continue
+
+        filtered.append(match)
+
+    if filtered:
+        return filtered[0]
+
+    return fallback_extract_hyphenated_verification_code(email_content)
+
+
+def smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern[str]) -> Optional[str]:
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        context = email_content[start:end]
+        for match in code_re.finditer(context):
+            value = match.group(0)
+            if value and any(c.isdigit() for c in value):
+                return value
+    return None
+
+
+def fallback_extract_code(email_content: str, code_re: re.Pattern[str]) -> Optional[str]:
+    if not email_content:
+        return None
+
+    candidates: List[str] = []
+    for match in code_re.finditer(email_content):
+        value = match.group(0) or ""
+        if not value or not any(c.isdigit() for c in value):
+            continue
+
+        if value.isdigit() and len(value) == 4:
+            year = int(value)
+            if 1900 <= year <= 2100:
+                continue
+            hour = int(value[:2])
+            minute = int(value[2:])
+            if 0 <= hour <= 23 and 0 <= minute <= 59:
+                continue
+            if 2020 <= year <= 2030:
+                continue
+
+        candidates.append(value)
+
+    return candidates[0] if candidates else None
+
+
+def extract_links(email_content: str) -> List[str]:
+    if not email_content:
+        return []
+
+    cleaned_links = [link.rstrip(".,;:!?)>'\"") for link in re.findall(LINK_PATTERN, email_content, re.IGNORECASE)]
+    seen: set[str] = set()
+    unique_links: List[str] = []
+    for link in cleaned_links:
+        if link not in seen:
+            seen.add(link)
+            unique_links.append(link)
+    return unique_links
+
+
+def pick_preferred_link(links: List[str], prefer_link_keywords: List[str]) -> Optional[str]:
+    if not links:
+        return None
+
+    keywords = [keyword.lower() for keyword in (prefer_link_keywords or []) if keyword]
+    if keywords:
+        for keyword in keywords:
+            for link in links:
+                if keyword in (link or "").lower():
+                    return link
+    return links[0]
+
+
+def build_source_text(email_input: VerificationInput, *, code_source: str) -> tuple[str, str]:
+    subject = email_input.subject
+    content = extract_content_text_without_subject(email_input)
+    html_raw = email_input.body_html or email_input.html_content
+
+    source = str(code_source or "all").strip().lower()
+    if source == "subject":
+        return subject, "subject"
+    if source == "content":
+        return content, "content"
+    if source == "html":
+        return (html_to_visible_text(html_raw) if html_raw else ""), "html"
+    return f"{subject} {content}".strip(), "all"
+
+
+def extract_verification_code_from_text(
+    source_text: str,
+    *,
+    code_regex: str | None,
+    code_length: str | None,
+) -> tuple[Optional[str], str]:
+    code_re = build_code_regex(code_regex=code_regex, code_length=code_length)
+    caller_directed_code = bool(code_regex)
+
+    verification_code = smart_extract_code_by_keywords(source_text, code_re)
+    code_confidence = "high" if verification_code else "low"
+
+    if not verification_code:
+        verification_code = fallback_extract_code(source_text, code_re)
+        if verification_code and caller_directed_code:
+            code_confidence = "high"
+
+    if not verification_code:
+        verification_code = smart_extract_hyphenated_verification_code(source_text)
+        if verification_code:
+            code_confidence = "high"
+
+    if not verification_code:
+        verification_code = fallback_extract_hyphenated_verification_code(source_text)
+        if verification_code:
+            code_confidence = "high"
+
+    return verification_code, code_confidence
+
+
+def extract_verification(
+    email_input: VerificationInput,
+    policy: VerificationPolicy | None = None,
+) -> Dict[str, Any]:
+    """
+    统一验证码/链接提取入口。
+
+    返回字段与 extract_verification_info_with_options 兼容。
+    """
+    active_policy = policy or VerificationPolicy()
+    source_text, match_source = build_source_text(email_input, code_source=active_policy.code_source)
+    subject = email_input.subject
+    content = extract_content_text_without_subject(email_input)
+    html_raw = email_input.body_html or email_input.html_content
+
+    verification_code, code_confidence = extract_verification_code_from_text(
+        source_text,
+        code_regex=active_policy.code_regex,
+        code_length=active_policy.code_length,
+    )
+
+    links = extract_links(f"{subject} {content} {html_raw}".strip())
+    prefer_keywords = active_policy.prefer_link_keywords or DEFAULT_LINK_KEYWORDS
+
+    verification_link = None
+    link_confidence = "low"
+    should_pick_link = (not active_policy.enforce_mutual_exclusion) or (not verification_code)
+    if should_pick_link:
+        verification_link = pick_preferred_link(links, prefer_keywords)
+        if verification_link:
+            for keyword in prefer_keywords:
+                if keyword and keyword.lower() in verification_link.lower():
+                    link_confidence = "high"
+                    break
+            if link_confidence != "high":
+                full_text_lower = f"{subject} {content}".lower()
+                for phrase in LINK_CONTEXT_PHRASES:
+                    if phrase.lower() in full_text_lower:
+                        link_confidence = "high"
+                        break
+
+    confidence = "high" if code_confidence == "high" or link_confidence == "high" else "low"
+
+    parts: List[str] = []
+    if verification_code:
+        parts.append(verification_code)
+    if verification_link:
+        parts.append(verification_link)
+    formatted = " ".join(parts) if parts else None
+
+    result = {
+        "verification_code": verification_code,
+        "verification_link": verification_link,
+        "links": links,
+        "formatted": formatted,
+        "match_source": match_source,
+        "confidence": confidence,
+        "code_confidence": code_confidence,
+        "link_confidence": link_confidence,
+    }
+
+    if active_policy.apply_confidence_gate:
+        result = apply_confidence_gate(result, enforce_mutual_exclusion=active_policy.enforce_mutual_exclusion)
+
+    expected_field = str(active_policy.expected_field or "").strip().lower()
+    if expected_field == "code":
+        result["verification_link"] = None
+        result["link_confidence"] = "low"
+        result["formatted"] = result.get("verification_code") or None
+    elif expected_field == "link":
+        result["verification_code"] = None
+        result["code_confidence"] = "low"
+        result["formatted"] = result.get("verification_link") or None
+
+    return result
+
+
+def apply_confidence_gate(extracted: Dict[str, Any], *, enforce_mutual_exclusion: bool = True) -> Dict[str, Any]:
+    result = dict(extracted)
+
+    if result.get("code_confidence") != "high":
+        result["verification_code"] = None
+    if result.get("link_confidence") != "high":
+        result["verification_link"] = None
+
+    if enforce_mutual_exclusion and result.get("verification_code"):
+        result["verification_link"] = None
+        result["link_confidence"] = "low"
+
+    parts = [value for value in (result.get("verification_code"), result.get("verification_link")) if value]
+    result["formatted"] = " ".join(parts) if parts else None
+    result["confidence"] = (
+        "high" if result.get("code_confidence") == "high" or result.get("link_confidence") == "high" else "low"
+    )
+    return result
+
+
+def policy_from_resolved(
+    resolved: Dict[str, Any] | None,
+    *,
+    code_source: str = "all",
+    enforce_mutual_exclusion: bool = True,
+    apply_confidence_gate: bool = False,
+    expected_field: str | None = None,
+) -> VerificationPolicy:
+    payload = resolved or {}
+    return VerificationPolicy(
+        code_regex=payload.get("code_regex"),
+        code_length=payload.get("code_length"),
+        code_source=code_source,
+        enforce_mutual_exclusion=enforce_mutual_exclusion,
+        apply_confidence_gate=apply_confidence_gate,
+        expected_field=expected_field,
+    )
+
+
+def extract_verification_from_email_dict(
+    email: Dict[str, Any],
+    *,
+    code_regex: str | None = None,
+    code_length: str | None = None,
+    code_source: str = "all",
+    prefer_link_keywords: list[str] | None = None,
+    enforce_mutual_exclusion: bool = True,
+    apply_confidence_gate_after: bool = False,
+) -> Dict[str, Any]:
+    """兼容旧 extract_verification_info_with_options 签名的薄封装。"""
+    policy = VerificationPolicy(
+        code_regex=code_regex,
+        code_length=code_length,
+        code_source=code_source,
+        prefer_link_keywords=list(prefer_link_keywords or DEFAULT_LINK_KEYWORDS),
+        enforce_mutual_exclusion=enforce_mutual_exclusion,
+        apply_confidence_gate=apply_confidence_gate_after,
+    )
+    return extract_verification(VerificationInput.from_email_dict(email), policy)

--- a/outlook_web/services/verification_extractor.py
+++ b/outlook_web/services/verification_extractor.py
@@ -1,606 +1,125 @@
 """
-验证码提取服务模块
+验证码提取服务模块（兼容层）
 
-提供从邮件内容中提取验证码和链接的功能，包括：
-- 智能验证码识别（基于关键词）
-- 保底验证码提取（正则匹配 + 过滤）
-- 链接提取（HTTP/HTTPS）
-- 邮件内容提取（HTML转纯文本）
+核心提取逻辑已收敛至 verification_code_extraction；本模块保留：
+- 向后兼容的函数签名
+- AI 回退与探测能力
 """
 
 from __future__ import annotations
 
-import html
 import json
 import logging
 import re
 import time
-from html.parser import HTMLParser
 from typing import Any, Dict, List, Optional
 
 import requests
 
 from outlook_web.repositories import settings as settings_repo
+from outlook_web.services import verification_code_extraction as vce
 
-# 验证码关键词列表（支持中英文）
-VERIFICATION_KEYWORDS = [
-    "验证码",
-    "code",
-    "验证",
-    "verification",
-    "OTP",
-    "动态码",
-    "校验码",
-    "verify code",
-    "confirmation code",
-    "security code",
-    "验证码是",
-    "your code",
-    "code is",
-    "激活码",
-    "短信验证码",
-]
-
-# 验证码模式（4-8位数字或字母，必须包含至少一个数字）
-VERIFICATION_PATTERN = r"\b[A-Z0-9]{4,8}\b"
-
-# 带连字符的字母数字验证码，例如 x.ai 的 84A-KMN。
-# x.ai HTML 常把验证码紧贴在句末（如 address.84A-KMNIf），因此允许验证码后接英文单词首字母。
-HYPHENATED_VERIFICATION_PATTERN = r"(?<![A-Z0-9])([A-Z0-9]{2,4}-[A-Z0-9]{2,4})(?=$|[^A-Z0-9-]|[A-Z][a-z])"
-
-# 验证码语境提权：出现这些短语时允许识别带连字符验证码，降低订单号/追踪号误判
-CODE_CONTEXT_PHRASES = [
-    "validate your email",
-    "validate your email address",
-    "code below",
-    "xai account",
-    "x.ai",
-    "support@x.ai",
-    "verification code",
-    "confirm your email",
-    "verify your email",
-    "your code",
-    "the code below",
-]
-
-# 链接正则表达式
-LINK_PATTERN = r'https?://[^\s<>"{}|\\^`\[\]]+'
-
-# 对外/参数化提取：验证链接优先关键词
-DEFAULT_LINK_KEYWORDS = [
-    "verify",
-    "confirmation",
-    "confirm",
-    "activate",
-    "validation",
-]
-
-# 链接语境提权：仅与"验证/激活账户/确认邮箱"强相关的完整短语
-# 必须带对象名词（email/account/邮箱/账户），避免 "confirm your order" 等交易邮件误触
-LINK_CONTEXT_PHRASES = [
-    "verify your email",
-    "verify your account",
-    "verify your address",
-    "confirm your email",
-    "confirm your account",
-    "confirm your address",
-    "activate your email",
-    "activate your account",
-    "email verification",
-    "account verification",
-    "验证您的邮箱",
-    "验证你的邮箱",
-    "验证您的账户",
-    "验证你的账户",
-    "验证您的账号",
-    "验证你的账号",
-    "确认您的邮箱",
-    "确认你的邮箱",
-    "确认您的账户",
-    "确认你的账户",
-    "激活您的账户",
-    "激活你的账户",
-    "激活您的邮箱",
-    "激活你的邮箱",
-    "邮箱验证",
-    "账号验证",
-    "账户验证",
-]
+# 向后兼容：旧代码从此模块导入常量与工具
+VERIFICATION_KEYWORDS = vce.VERIFICATION_KEYWORDS
+VERIFICATION_PATTERN = vce.VERIFICATION_PATTERN
+HYPHENATED_VERIFICATION_PATTERN = vce.HYPHENATED_VERIFICATION_PATTERN
+CODE_CONTEXT_PHRASES = vce.CODE_CONTEXT_PHRASES
+LINK_PATTERN = vce.LINK_PATTERN
+DEFAULT_LINK_KEYWORDS = vce.DEFAULT_LINK_KEYWORDS
+LINK_CONTEXT_PHRASES = vce.LINK_CONTEXT_PHRASES
+HTMLTextExtractor = vce.HTMLTextExtractor
 
 VERIFICATION_AI_SCHEMA_VERSION = "verification_ai_v1"
 _LOGGER = logging.getLogger("outlook_web.services.verification_extractor")
 
 
-class HTMLTextExtractor(HTMLParser):
-    """HTML 转纯文本提取器"""
-
-    def __init__(self):
-        super().__init__()
-        self.text_parts = []
-        self._skip_tags = {"style", "script", "head", "meta", "link"}
-        self._current_skip = False
-
-    def handle_starttag(self, tag, attrs):
-        if tag.lower() in self._skip_tags:
-            self._current_skip = True
-
-    def handle_endtag(self, tag):
-        if tag.lower() in self._skip_tags:
-            self._current_skip = False
-
-    def handle_data(self, data):
-        if not self._current_skip and data.strip():
-            self.text_parts.append(data.strip())
-
-    def get_text(self) -> str:
-        return " ".join(self.text_parts)
-
-
 def _is_valid_hyphenated_code(code: str) -> bool:
-    """校验带连字符验证码：两段字母数字、总长 4-10。
-
-    x.ai 常见两种形态：
-    - 含数字：84A-KMN
-    - 全大写字母：NJF-KUU（无数字，但两段均 >=3 且总长 >=6）
-    """
-    if not code or "-" not in code:
-        return False
-
-    parts = code.split("-")
-    if len(parts) != 2:
-        return False
-    if not all(part.isalnum() for part in parts):
-        return False
-
-    alnum = "".join(parts)
-    if not (4 <= len(alnum) <= 10):
-        return False
-    if any(c.isdigit() for c in alnum):
-        return True
-    # x.ai 全字母验证码（如 NJF-KUU）
-    return len(alnum) >= 6 and all(len(part) >= 3 for part in parts) and alnum.isalpha()
+    return vce._is_valid_hyphenated_code(code)
 
 
 def _has_code_context(email_content: str) -> bool:
-    content_lower = email_content.lower()
-    return any(phrase.lower() in content_lower for phrase in CODE_CONTEXT_PHRASES)
+    return vce._has_code_context(email_content)
 
 
 def _find_hyphenated_code_in_text(text: str) -> Optional[str]:
-    if not text:
-        return None
-
-    for match in re.finditer(HYPHENATED_VERIFICATION_PATTERN, text, re.IGNORECASE):
-        code = match.group(1)
-        if _is_valid_hyphenated_code(code):
-            return code
-    return None
+    return vce._find_hyphenated_code_in_text(text)
 
 
 def _smart_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
-    """在验证码关键词附近搜索带连字符验证码。"""
-    if not email_content:
-        return None
-
-    content_lower = email_content.lower()
-    for keyword in VERIFICATION_KEYWORDS:
-        keyword_lower = keyword.lower()
-        pos = content_lower.find(keyword_lower)
-        if pos == -1:
-            continue
-
-        start = max(0, pos - 50)
-        end = min(len(email_content), pos + len(keyword) + 50)
-        code = _find_hyphenated_code_in_text(email_content[start:end])
-        if code:
-            return code
-    return None
+    return vce.smart_extract_hyphenated_verification_code(email_content)
 
 
 def _fallback_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
-    """在验证码语境明确时，从全文搜索带连字符验证码。"""
-    if not email_content or not _has_code_context(email_content):
-        return None
-    return _find_hyphenated_code_in_text(email_content)
+    return vce.fallback_extract_hyphenated_verification_code(email_content)
 
 
 def smart_extract_verification_code(email_content: str) -> Optional[str]:
-    """
-    智能提取验证码（基于关键词）
-
-    算法：
-    1. 遍历关键词列表
-    2. 在邮件内容中查找关键词位置
-    3. 在关键词前后 50 个字符范围内搜索验证码模式
-    4. 返回第一个匹配的验证码（必须包含数字）
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        验证码字符串，未找到返回 None
-    """
-    if not email_content:
-        return None
-
-    content_lower = email_content.lower()
-
-    for keyword in VERIFICATION_KEYWORDS:
-        keyword_lower = keyword.lower()
-        pos = content_lower.find(keyword_lower)
-
-        if pos != -1:
-            # 提取关键词前后 50 个字符的上下文
-            start = max(0, pos - 50)
-            end = min(len(email_content), pos + len(keyword) + 50)
-            context = email_content[start:end]
-
-            # 在上下文中搜索验证码
-            matches = re.findall(VERIFICATION_PATTERN, context, re.IGNORECASE)
-            if matches:
-                # 过滤掉纯字母的匹配（验证码通常包含数字）
-                for match in matches:
-                    if any(c.isdigit() for c in match):
-                        return match
-
-    hyphenated_code = _smart_extract_hyphenated_verification_code(email_content)
-    if hyphenated_code:
-        return hyphenated_code
-
-    return None
+    return vce.smart_extract_verification_code(email_content)
 
 
 def fallback_extract_verification_code(email_content: str) -> Optional[str]:
-    """
-    保底提取验证码（正则匹配 + 过滤）
-
-    算法：
-    1. 提取所有 4-8 位的数字/字母组合
-    2. 过滤掉常见的非验证码模式（日期、时间等）
-    3. 返回第一个匹配项
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        验证码字符串，未找到返回 None
-    """
-    if not email_content:
-        return None
-
-    # 提取所有可能的验证码
-    matches = re.findall(VERIFICATION_PATTERN, email_content, re.IGNORECASE)
-
-    # 过滤规则
-    filtered = []
-    for match in matches:
-        # 必须包含至少一个数字
-        if not any(c.isdigit() for c in match):
-            continue
-
-        # 排除纯数字且长度为 4 的（可能是年份）
-        if match.isdigit() and len(match) == 4:
-            year = int(match)
-            if 1900 <= year <= 2100:
-                continue
-
-        # 排除常见的时间格式（如 1234 可能是 12:34）
-        if match.isdigit() and len(match) == 4:
-            hour = int(match[:2])
-            minute = int(match[2:])
-            if 0 <= hour <= 23 and 0 <= minute <= 59:
-                continue
-
-        # 排除常见的 4 位数字编号（如 2024、2025 等年份）
-        if match.isdigit() and len(match) == 4:
-            # 年份范围检查
-            num = int(match)
-            if 2020 <= num <= 2030:
-                continue
-
-        filtered.append(match)
-
-    if filtered:
-        return filtered[0]
-
-    return _fallback_extract_hyphenated_verification_code(email_content)
+    return vce.fallback_extract_verification_code(email_content)
 
 
 def extract_links(email_content: str) -> List[str]:
-    """
-    提取所有 HTTP/HTTPS 链接
-
-    算法：
-    1. 使用正则表达式提取所有链接
-    2. 去重并保持顺序
-    3. 清理链接末尾的标点符号
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        去重后的链接列表
-    """
-    if not email_content:
-        return []
-
-    matches = re.findall(LINK_PATTERN, email_content, re.IGNORECASE)
-
-    # 清理链接（移除末尾的标点符号）
-    cleaned_links = []
-    for link in matches:
-        # 移除末尾的标点符号
-        cleaned = link.rstrip(".,;:!?)>'\"")
-        cleaned_links.append(cleaned)
-
-    # 去重并保持顺序
-    seen = set()
-    unique_links = []
-    for link in cleaned_links:
-        if link not in seen:
-            seen.add(link)
-            unique_links.append(link)
-
-    return unique_links
+    return vce.extract_links(email_content)
 
 
 def extract_email_text(email: Dict[str, Any]) -> str:
-    """
-    从邮件对象提取纯文本内容
-
-    优先级：
-    1. body（纯文本）
-    2. body_html（HTML 转纯文本）
-    3. body_preview（预览文本）
-
-    Args:
-        email: 邮件对象字典
-
-    Returns:
-        提取的纯文本内容
-
-    Raises:
-        ValueError: 邮件内容为空
-    """
-    # 优先使用纯文本
-    if email.get("body") and email["body"].strip():
-        return email["body"].strip()
-
-    # 其次使用 HTML 转纯文本
-    if email.get("body_html") and email["body_html"].strip():
-        parser = HTMLTextExtractor()
-        try:
-            parser.feed(email["body_html"])
-            text = parser.get_text()
-            # 解码 HTML 实体
-            text = html.unescape(text)
-            if text.strip():
-                return text.strip()
-        except Exception:
-            pass
-
-    # 再次尝试使用 bodyContent（Graph API 格式）
-    if email.get("bodyContent") and email["bodyContent"].strip():
-        content = email["bodyContent"]
-        # 如果是 HTML，需要转换
-        if email.get("bodyContentType") == "html":
-            parser = HTMLTextExtractor()
-            try:
-                parser.feed(content)
-                text = parser.get_text()
-                text = html.unescape(text)
-                if text.strip():
-                    return text.strip()
-            except Exception:
-                pass
-        else:
-            return content.strip()
-
-    # 最后使用预览文本
-    if email.get("body_preview") and email["body_preview"].strip():
-        return email["body_preview"].strip()
-
-    # 使用 subject 作为补充
-    if email.get("subject") and email["subject"].strip():
-        return email["subject"].strip()
-
-    return ""
+    return vce.extract_email_text(email)
 
 
 def extract_verification_info_from_text(email_content: str) -> Dict[str, Any]:
-    """
-    从文本内容提取验证信息
-
-    Args:
-        email_content: 邮件文本内容
-
-    Returns:
-        包含验证码、链接和格式化输出的字典
-    """
-    # 提取验证码（智能识别 + 保底）
     verification_code = smart_extract_verification_code(email_content)
     if not verification_code:
         verification_code = fallback_extract_verification_code(email_content)
 
-    # 提取链接
     links = extract_links(email_content)
-
-    # 格式化输出
-    parts = []
+    parts: List[str] = []
     if verification_code:
         parts.append(verification_code)
     parts.extend(links)
 
-    formatted = " ".join(parts) if parts else None
-
     return {
         "verification_code": verification_code,
         "links": links,
-        "formatted": formatted,
+        "formatted": " ".join(parts) if parts else None,
     }
 
 
 def extract_verification_info(email: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    从邮件对象提取验证信息的完整流程
-
-    Args:
-        email: 邮件对象字典
-
-    Returns:
-        包含验证码、链接和格式化输出的字典
-
-    Raises:
-        ValueError: 未找到验证信息
-    """
-    # 提取邮件文本内容
     email_content = extract_email_text(email)
-
     if not email_content:
         raise ValueError("邮件内容为空")
 
-    # 提取验证信息
     result = extract_verification_info_from_text(email_content)
-
     if not result["formatted"]:
         raise ValueError("未找到验证信息")
-
     return result
 
 
 def _extract_content_text_without_subject(email: Dict[str, Any]) -> str:
-    """
-    仅提取邮件正文/预览（不回退到 subject）。
-
-    注意：extract_email_text() 会在末尾回退 subject；该函数用于 code_source=content 时严格遵循语义。
-    """
-    # 优先使用纯文本
-    if email.get("body") and str(email["body"]).strip():
-        return str(email["body"]).strip()
-
-    # 其次使用 HTML 转纯文本
-    if email.get("body_html") and str(email["body_html"]).strip():
-        parser = HTMLTextExtractor()
-        try:
-            parser.feed(str(email["body_html"]))
-            text = html.unescape(parser.get_text() or "")
-            return text.strip()
-        except Exception:
-            return ""
-
-    # Graph API 格式 bodyContent/bodyContentType
-    if email.get("bodyContent") and str(email["bodyContent"]).strip():
-        content = str(email["bodyContent"])
-        if str(email.get("bodyContentType") or "").lower() == "html":
-            parser = HTMLTextExtractor()
-            try:
-                parser.feed(content)
-                text = html.unescape(parser.get_text() or "")
-                return text.strip()
-            except Exception:
-                return ""
-        return content.strip()
-
-    if email.get("body_preview") and str(email["body_preview"]).strip():
-        return str(email["body_preview"]).strip()
-
-    return ""
+    return vce.extract_content_text_without_subject(vce.VerificationInput.from_email_dict(email))
 
 
 def _parse_code_length(code_length: str) -> tuple[int, int]:
-    m = re.match(r"^(\d+)-(\d+)$", str(code_length or "").strip())
-    if not m:
-        raise ValueError("code_length 参数无效")
-    min_len = int(m.group(1))
-    max_len = int(m.group(2))
-    if min_len <= 0 or max_len <= 0 or min_len > max_len:
-        raise ValueError("code_length 参数无效")
-    return min_len, max_len
+    return vce._parse_code_length(code_length)
 
 
-def _build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.Pattern:
-    if code_regex:
-        try:
-            return re.compile(code_regex)
-        except re.error as exc:
-            raise ValueError("code_regex 参数无效") from exc
-
-    if code_length:
-        min_len, max_len = _parse_code_length(code_length)
-        return re.compile(rf"\b[A-Za-z0-9]{{{min_len},{max_len}}}\b")
-
-    # 默认：4-8 位数字验证码；字母数字验证码由 group/request 的 code_length 策略启用。
-    return re.compile(r"\b\d{4,8}\b")
+def _build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.Pattern[str]:
+    return vce.build_code_regex(code_regex=code_regex, code_length=code_length)
 
 
-def _smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern) -> Optional[str]:
-    if not email_content:
-        return None
-
-    content_lower = email_content.lower()
-
-    for keyword in VERIFICATION_KEYWORDS:
-        keyword_lower = keyword.lower()
-        pos = content_lower.find(keyword_lower)
-        if pos == -1:
-            continue
-
-        start = max(0, pos - 50)
-        end = min(len(email_content), pos + len(keyword) + 50)
-        context = email_content[start:end]
-
-        for m in code_re.finditer(context):
-            value = m.group(0)
-            if value and any(c.isdigit() for c in value):
-                return value
-
-    return None
+def _smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern[str]) -> Optional[str]:
+    return vce.smart_extract_code_by_keywords(email_content, code_re)
 
 
-def _fallback_extract_code(email_content: str, code_re: re.Pattern) -> Optional[str]:
-    if not email_content:
-        return None
-
-    candidates: List[str] = []
-    for m in code_re.finditer(email_content):
-        value = m.group(0) or ""
-        if not value:
-            continue
-
-        # 与现有提取器保持一致：必须包含至少一个数字
-        if not any(c.isdigit() for c in value):
-            continue
-
-        # 过滤常见误判（仅对纯数字候选生效）
-        if value.isdigit() and len(value) == 4:
-            year = int(value)
-            if 1900 <= year <= 2100:
-                continue
-            hour = int(value[:2])
-            minute = int(value[2:])
-            if 0 <= hour <= 23 and 0 <= minute <= 59:
-                continue
-            num = int(value)
-            if 2020 <= num <= 2030:
-                continue
-
-        candidates.append(value)
-
-    return candidates[0] if candidates else None
+def _fallback_extract_code(email_content: str, code_re: re.Pattern[str]) -> Optional[str]:
+    return vce.fallback_extract_code(email_content, code_re)
 
 
 def _pick_preferred_link(links: List[str], prefer_link_keywords: List[str]) -> Optional[str]:
-    if not links:
-        return None
-
-    keywords = [k.lower() for k in (prefer_link_keywords or []) if k]
-    if keywords:
-        for keyword in keywords:
-            for link in links:
-                if keyword in (link or "").lower():
-                    return link
-
-    return links[0]
+    return vce.pick_preferred_link(links, prefer_link_keywords)
 
 
 def extract_verification_info_with_options(
@@ -612,158 +131,22 @@ def extract_verification_info_with_options(
     prefer_link_keywords: list[str] | None = None,
     enforce_mutual_exclusion: bool = True,
 ) -> Dict[str, Any]:
-    """
-    在现有提取器基础上支持：
-    - 自定义验证码正则（code_regex）
-    - 自定义验证码长度范围（code_length，如 4-8 / 6-6）
-    - 提取来源限定（subject/content/html/all）
-    - 验证链接关键词优先级（prefer_link_keywords）
-
-    返回结构为兼容扩展字典：
-    - verification_code
-    - verification_link
-    - links
-    - formatted
-    - match_source
-    - confidence          (向后兼容：code/link 中较高者)
-    - code_confidence      (high=关键词命中或调用方指定code_regex命中, low=仅 fallback 或未命中)
-    - link_confidence      (high=链接含验证关键词或邮件正文含强验证语境短语, low=任意首链接且无验证语境)
-
-    注意：该函数主要服务外部 API，不主动抛“未找到验证码/链接”的异常，方便上层按需映射错误码。
-    """
-    subject = str(email.get("subject") or "").strip()
-    content = _extract_content_text_without_subject(email)
-    html_content = str(email.get("body_html") or email.get("html_content") or "").strip()
-
-    source = str(code_source or "all").strip().lower()
-    if source == "subject":
-        source_text = subject
-        match_source = "subject"
-    elif source == "content":
-        source_text = content
-        match_source = "content"
-    elif source == "html":
-        if html_content:
-            parser = HTMLTextExtractor()
-            try:
-                parser.feed(html_content)
-                source_text = html.unescape(parser.get_text() or "").strip()
-            except Exception:
-                source_text = html_content
-        else:
-            source_text = ""
-        match_source = "html"
-    else:
-        # all：content 已含 HTML 转纯文本；勿再拼接原始 HTML，避免 CSS 色值（如 #333333）误判
-        source_text = f"{subject} {content}".strip()
-        match_source = "all"
-
-    code_re = _build_code_regex(code_regex=code_regex, code_length=code_length)
-    # 仅 code_regex 具有判别力，code_length 只是宽度约束，不自动提权
-    caller_directed_code = bool(code_regex)
-
-    # ── 验证码提取 & 置信度 ──
-    verification_code = _smart_extract_code_by_keywords(source_text, code_re)
-    code_confidence: str = "high" if verification_code else "low"
-    if not verification_code:
-        verification_code = _fallback_extract_code(source_text, code_re)
-        # 调用方显式指定了 code_regex（强判别力正则）→ 提取命中即视为可信
-        if verification_code and caller_directed_code:
-            code_confidence = "high"
-    if not verification_code:
-        verification_code = _smart_extract_hyphenated_verification_code(source_text)
-        if verification_code:
-            code_confidence = "high"
-    if not verification_code:
-        verification_code = _fallback_extract_hyphenated_verification_code(source_text)
-        if verification_code:
-            code_confidence = "high"
-
-    # ── 链接提取 & 置信度 ──
-    links = extract_links(f"{subject} {content} {html_content}".strip())
-    prefer_keywords = prefer_link_keywords or DEFAULT_LINK_KEYWORDS
-
-    verification_link = None
-    link_confidence: str = "low"
-    should_pick_link = (not enforce_mutual_exclusion) or (not verification_code)
-    if should_pick_link:
-        verification_link = _pick_preferred_link(links, prefer_keywords)
-        if verification_link:
-            # 优先检查 URL 本身是否含验证关键词
-            for kw in prefer_keywords:
-                if kw and kw.lower() in verification_link.lower():
-                    link_confidence = "high"
-                    break
-            # URL 不含关键词时，检查邮件正文/主题是否有强验证语境短语
-            if link_confidence != "high":
-                full_text_lower = f"{subject} {content}".lower()
-                for phrase in LINK_CONTEXT_PHRASES:
-                    if phrase.lower() in full_text_lower:
-                        link_confidence = "high"
-                        break
-
-    # 总 confidence 向后兼容：取 code / link 中较高者
-    confidence = "high" if code_confidence == "high" or link_confidence == "high" else "low"
-
-    parts: List[str] = []
-    if verification_code:
-        parts.append(verification_code)
-    if verification_link:
-        parts.append(verification_link)
-    formatted = " ".join(parts) if parts else None
-
-    return {
-        "verification_code": verification_code,
-        "verification_link": verification_link,
-        "links": links,
-        "formatted": formatted,
-        "match_source": match_source,
-        "confidence": confidence,
-        "code_confidence": code_confidence,
-        "link_confidence": link_confidence,
-    }
+    return vce.extract_verification_from_email_dict(
+        email,
+        code_regex=code_regex,
+        code_length=code_length,
+        code_source=code_source,
+        prefer_link_keywords=prefer_link_keywords,
+        enforce_mutual_exclusion=enforce_mutual_exclusion,
+        apply_confidence_gate_after=False,
+    )
 
 
 def apply_confidence_gate(extracted: Dict[str, Any], *, enforce_mutual_exclusion: bool = True) -> Dict[str, Any]:
-    """
-    对 extract_verification_info_with_options() 的返回结果应用置信度门控。
-
-    规则：
-    - code_confidence != "high"  → verification_code 置 None
-    - link_confidence != "high"  → verification_link 置 None
-    - 重算 formatted 与 confidence 以保持一致
-
-    用途：外部 API 和临时邮箱验证码提取均应调用此函数，
-    确保两条路径使用完全相同的门控标准，避免逻辑漂移。
-
-    Args:
-        extracted: extract_verification_info_with_options() 的返回值（原地修改一份拷贝）
-
-    Returns:
-        门控后的字典（不修改原始 extracted，返回新字典）
-    """
-    result = dict(extracted)
-
-    if result.get("code_confidence") != "high":
-        result["verification_code"] = None
-    if result.get("link_confidence") != "high":
-        result["verification_link"] = None
-
-    # 产品策略：严格互斥（code 优先）
-    if enforce_mutual_exclusion and result.get("verification_code"):
-        result["verification_link"] = None
-        result["link_confidence"] = "low"
-
-    parts = [v for v in (result.get("verification_code"), result.get("verification_link")) if v]
-    result["formatted"] = " ".join(parts) if parts else None
-    result["confidence"] = (
-        "high" if result.get("code_confidence") == "high" or result.get("link_confidence") == "high" else "low"
-    )
-    return result
+    return vce.apply_confidence_gate(extracted, enforce_mutual_exclusion=enforce_mutual_exclusion)
 
 
 def get_verification_ai_runtime_config() -> Dict[str, Any]:
-    """读取系统级验证码 AI 配置。"""
     return {
         "enabled": settings_repo.get_verification_ai_enabled(),
         "base_url": settings_repo.get_verification_ai_base_url(),
@@ -788,7 +171,6 @@ def build_verification_ai_input_payload(
     code_length: str | None = None,
     code_source: str = "all",
 ) -> Dict[str, Any]:
-    """构造固定 JSON 输入契约。"""
     return {
         "schema_version": VERIFICATION_AI_SCHEMA_VERSION,
         "task": "extract_verification",
@@ -850,8 +232,8 @@ def _parse_verification_ai_content(raw_content: str) -> Optional[Dict[str, Any]]
                 return "low"
         if isinstance(value, bool):
             return "high" if value else "low"
-        text = str(value or "").strip().lower()
-        if text in {"high", "medium", "1", "true", "yes"}:
+        text_value = str(value or "").strip().lower()
+        if text_value in {"high", "medium", "1", "true", "yes"}:
             return "high"
         return "low"
 
@@ -935,16 +317,6 @@ def probe_verification_ai_runtime(
     code_source: str = "all",
     timeout_seconds: int = 8,
 ) -> Dict[str, Any]:
-    """
-    诊断用：主动探测系统级验证码 AI 配置是否可用。
-
-    返回结构（不包含敏感信息）：
-    - ok: bool
-    - error: 错误类别（config_incomplete/http_error/request_failed/invalid_ai_output/invalid_response_format）
-    - message: 人类可读说明
-    - endpoint/model/http_status/latency_ms
-    - parsed_output: 合法输出时返回固定 JSON 契约对象
-    """
     endpoint = _normalize_verification_ai_endpoint(str((ai_config or {}).get("base_url") or ""))
     model = str((ai_config or {}).get("model") or "").strip()
     api_key = str((ai_config or {}).get("api_key") or "").strip()
@@ -1108,18 +480,9 @@ def enhance_verification_with_ai_fallback(
     code_source: str = "all",
     enforce_mutual_exclusion: bool = True,
 ) -> Dict[str, Any]:
-    """
-    规则优先、AI 回退：
-    - 任一字段高置信即跳过 AI（方案 A：一个 high 就够了）
-    - 仅在 code/link 均为 low 时才触发 AI
-    - AI 无效/异常时快速回退规则结果
-    """
-
     def _apply_output_policy(payload: Dict[str, Any]) -> Dict[str, Any]:
-        """统一收口：强制 code/link 严格互斥并重算格式字段。"""
         normalized = dict(payload or {})
 
-        # 产品策略：有 code（无论置信度）时，不返回 verification_link
         if enforce_mutual_exclusion and normalized.get("verification_code"):
             normalized["verification_link"] = None
             normalized["link_confidence"] = "low"
@@ -1139,7 +502,6 @@ def enhance_verification_with_ai_fallback(
 
     code_confidence = str(result.get("code_confidence") or "low").lower()
     link_confidence = str(result.get("link_confidence") or "low").lower()
-    # 方案 A：任一 high 即跳过 AI，只有 both-low 才触发
     if code_confidence == "high" or link_confidence == "high":
         return _apply_output_policy(result)
 

--- a/outlook_web/services/verification_extractor.py
+++ b/outlook_web/services/verification_extractor.py
@@ -44,6 +44,25 @@ VERIFICATION_KEYWORDS = [
 # 验证码模式（4-8位数字或字母，必须包含至少一个数字）
 VERIFICATION_PATTERN = r"\b[A-Z0-9]{4,8}\b"
 
+# 带连字符的字母数字验证码，例如 x.ai 的 84A-KMN。
+# x.ai HTML 常把验证码紧贴在句末（如 address.84A-KMNIf），因此允许验证码后接英文单词首字母。
+HYPHENATED_VERIFICATION_PATTERN = r"(?<![A-Z0-9])([A-Z0-9]{2,4}-[A-Z0-9]{2,4})(?=$|[^A-Z0-9-]|[A-Z][a-z])"
+
+# 验证码语境提权：出现这些短语时允许识别带连字符验证码，降低订单号/追踪号误判
+CODE_CONTEXT_PHRASES = [
+    "validate your email",
+    "validate your email address",
+    "code below",
+    "xai account",
+    "x.ai",
+    "support@x.ai",
+    "verification code",
+    "confirm your email",
+    "verify your email",
+    "your code",
+    "the code below",
+]
+
 # 链接正则表达式
 LINK_PATTERN = r'https?://[^\s<>"{}|\\^`\[\]]+'
 
@@ -117,6 +136,74 @@ class HTMLTextExtractor(HTMLParser):
         return " ".join(self.text_parts)
 
 
+def _is_valid_hyphenated_code(code: str) -> bool:
+    """校验带连字符验证码：两段字母数字、总长 4-10。
+
+    x.ai 常见两种形态：
+    - 含数字：84A-KMN
+    - 全大写字母：NJF-KUU（无数字，但两段均 >=3 且总长 >=6）
+    """
+    if not code or "-" not in code:
+        return False
+
+    parts = code.split("-")
+    if len(parts) != 2:
+        return False
+    if not all(part.isalnum() for part in parts):
+        return False
+
+    alnum = "".join(parts)
+    if not (4 <= len(alnum) <= 10):
+        return False
+    if any(c.isdigit() for c in alnum):
+        return True
+    # x.ai 全字母验证码（如 NJF-KUU）
+    return len(alnum) >= 6 and all(len(part) >= 3 for part in parts) and alnum.isalpha()
+
+
+def _has_code_context(email_content: str) -> bool:
+    content_lower = email_content.lower()
+    return any(phrase.lower() in content_lower for phrase in CODE_CONTEXT_PHRASES)
+
+
+def _find_hyphenated_code_in_text(text: str) -> Optional[str]:
+    if not text:
+        return None
+
+    for match in re.finditer(HYPHENATED_VERIFICATION_PATTERN, text, re.IGNORECASE):
+        code = match.group(1)
+        if _is_valid_hyphenated_code(code):
+            return code
+    return None
+
+
+def _smart_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    """在验证码关键词附近搜索带连字符验证码。"""
+    if not email_content:
+        return None
+
+    content_lower = email_content.lower()
+    for keyword in VERIFICATION_KEYWORDS:
+        keyword_lower = keyword.lower()
+        pos = content_lower.find(keyword_lower)
+        if pos == -1:
+            continue
+
+        start = max(0, pos - 50)
+        end = min(len(email_content), pos + len(keyword) + 50)
+        code = _find_hyphenated_code_in_text(email_content[start:end])
+        if code:
+            return code
+    return None
+
+
+def _fallback_extract_hyphenated_verification_code(email_content: str) -> Optional[str]:
+    """在验证码语境明确时，从全文搜索带连字符验证码。"""
+    if not email_content or not _has_code_context(email_content):
+        return None
+    return _find_hyphenated_code_in_text(email_content)
+
+
 def smart_extract_verification_code(email_content: str) -> Optional[str]:
     """
     智能提取验证码（基于关键词）
@@ -154,7 +241,11 @@ def smart_extract_verification_code(email_content: str) -> Optional[str]:
                 # 过滤掉纯字母的匹配（验证码通常包含数字）
                 for match in matches:
                     if any(c.isdigit() for c in match):
-                        return match.upper()
+                        return match
+
+    hyphenated_code = _smart_extract_hyphenated_verification_code(email_content)
+    if hyphenated_code:
+        return hyphenated_code
 
     return None
 
@@ -183,8 +274,6 @@ def fallback_extract_verification_code(email_content: str) -> Optional[str]:
     # 过滤规则
     filtered = []
     for match in matches:
-        match_upper = match.upper()
-
         # 必须包含至少一个数字
         if not any(c.isdigit() for c in match):
             continue
@@ -209,9 +298,12 @@ def fallback_extract_verification_code(email_content: str) -> Optional[str]:
             if 2020 <= num <= 2030:
                 continue
 
-        filtered.append(match_upper)
+        filtered.append(match)
 
-    return filtered[0] if filtered else None
+    if filtered:
+        return filtered[0]
+
+    return _fallback_extract_hyphenated_verification_code(email_content)
 
 
 def extract_links(email_content: str) -> List[str]:
@@ -435,9 +527,9 @@ def _build_code_regex(*, code_regex: str | None, code_length: str | None) -> re.
 
     if code_length:
         min_len, max_len = _parse_code_length(code_length)
-        return re.compile(rf"\b\d{{{min_len},{max_len}}}\b")
+        return re.compile(rf"\b[A-Za-z0-9]{{{min_len},{max_len}}}\b")
 
-    # 默认：4-8 位数字验证码（更贴近“验证码”场景）
+    # 默认：4-8 位数字验证码；字母数字验证码由 group/request 的 code_length 策略启用。
     return re.compile(r"\b\d{4,8}\b")
 
 
@@ -460,7 +552,7 @@ def _smart_extract_code_by_keywords(email_content: str, code_re: re.Pattern) -> 
         for m in code_re.finditer(context):
             value = m.group(0)
             if value and any(c.isdigit() for c in value):
-                return value.upper()
+                return value
 
     return None
 
@@ -492,7 +584,7 @@ def _fallback_extract_code(email_content: str, code_re: re.Pattern) -> Optional[
             if 2020 <= num <= 2030:
                 continue
 
-        candidates.append(value.upper())
+        candidates.append(value)
 
     return candidates[0] if candidates else None
 
@@ -551,10 +643,19 @@ def extract_verification_info_with_options(
         source_text = content
         match_source = "content"
     elif source == "html":
-        source_text = html_content
+        if html_content:
+            parser = HTMLTextExtractor()
+            try:
+                parser.feed(html_content)
+                source_text = html.unescape(parser.get_text() or "").strip()
+            except Exception:
+                source_text = html_content
+        else:
+            source_text = ""
         match_source = "html"
     else:
-        source_text = f"{subject} {content} {html_content}".strip()
+        # all：content 已含 HTML 转纯文本；勿再拼接原始 HTML，避免 CSS 色值（如 #333333）误判
+        source_text = f"{subject} {content}".strip()
         match_source = "all"
 
     code_re = _build_code_regex(code_regex=code_regex, code_length=code_length)
@@ -568,6 +669,14 @@ def extract_verification_info_with_options(
         verification_code = _fallback_extract_code(source_text, code_re)
         # 调用方显式指定了 code_regex（强判别力正则）→ 提取命中即视为可信
         if verification_code and caller_directed_code:
+            code_confidence = "high"
+    if not verification_code:
+        verification_code = _smart_extract_hyphenated_verification_code(source_text)
+        if verification_code:
+            code_confidence = "high"
+    if not verification_code:
+        verification_code = _fallback_extract_hyphenated_verification_code(source_text)
+        if verification_code:
             code_confidence = "high"
 
     # ── 链接提取 & 置信度 ──
@@ -1055,7 +1164,7 @@ def enhance_verification_with_ai_fallback(
 
     updated = False
     if ai_code:
-        result["verification_code"] = ai_code.upper()
+        result["verification_code"] = ai_code
         result["code_confidence"] = "high" if ai_confidence == "high" else "low"
         updated = True
     if ai_link:

--- a/static/js/features/groups.js
+++ b/static/js/features/groups.js
@@ -865,10 +865,12 @@
 
         function buildVerificationExtractEndpoint(email, options = {}) {
             const normalizedSource = String(options?.source || '').trim().toLowerCase();
+            const field = String(options?.field || 'any').trim().toLowerCase();
+            const query = field && field !== 'any' ? `?field=${encodeURIComponent(field)}` : '';
             if (normalizedSource === 'temp' || normalizedSource === 'temp-mail' || normalizedSource === 'temp_mail') {
-                return `/api/temp-emails/${encodeURIComponent(email)}/extract-verification`;
+                return `/api/temp-emails/${encodeURIComponent(email)}/verification${query}`;
             }
-            return `/api/emails/${encodeURIComponent(email)}/extract-verification`;
+            return `/api/emails/${encodeURIComponent(email)}/verification${query}`;
         }
 
         async function tryFallbackVerificationExtraction(options = {}) {

--- a/static/js/features/mailbox_compact.js
+++ b/static/js/features/mailbox_compact.js
@@ -146,25 +146,12 @@
                 return;
             }
 
-            if (account.latest_verification_code) {
-                try {
-                    await copyToClipboard(account.latest_verification_code);
-                    showToast(
-                        getUiLanguage() === 'en'
-                            ? `Copied: ${account.latest_verification_code}`
-                            : `已复制: ${account.latest_verification_code}`,
-                        'success'
-                    );
-                    return;
-                } catch (error) {
-                    showToast(translateCompactText('复制验证码失败'), 'error');
-                    return;
-                }
+            if (!account.email || !buttonElement || typeof copyVerificationInfo !== 'function') {
+                showToast(translateCompactText('复制验证码失败'), 'error');
+                return;
             }
 
-            if (buttonElement) {
-                copyVerificationInfo(account.email, buttonElement);
-            }
+            return copyVerificationInfo(account.email, buttonElement);
         }
 
         function openCompactSingleTagModal(accountId) {

--- a/tests/compact-poll/compact-poll-engine.test.js
+++ b/tests/compact-poll/compact-poll-engine.test.js
@@ -541,7 +541,7 @@ describe('TC-C15~C16: 发现新邮件处理', () => {
 
     global.fetch = jest.fn().mockImplementation((url) => {
       // 验证码提取接口
-      if (url.includes('extract-verification')) {
+      if (url.includes('verification')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
@@ -586,7 +586,7 @@ describe('TC-C15~C16: 发现新邮件处理', () => {
 
     // 应调用验证码提取接口
     const extractCalls = global.fetch.mock.calls.filter(
-      ([url]) => url.includes('extract-verification')
+      ([url]) => url.includes('verification')
     );
     expect(extractCalls.length).toBeGreaterThan(0);
 
@@ -617,7 +617,7 @@ describe('TC-C15~C16: 发现新邮件处理', () => {
     let pollCallCount = 0;
 
     global.fetch = jest.fn().mockImplementation((url) => {
-      if (url.includes('extract-verification')) {
+      if (url.includes('verification')) {
         // 提取接口返回"无验证码"
         return Promise.resolve({
           ok: true,

--- a/tests/test_temp_mail_target_contract.py
+++ b/tests/test_temp_mail_target_contract.py
@@ -376,7 +376,7 @@ class TempMailTargetContractTests(unittest.TestCase):
         combined = groups_js + "\n" + temp_js + "\n" + emails_js
 
         self.assertIn("/api/temp-emails/", combined)
-        self.assertIn("extract-verification", combined)
+        self.assertIn("/verification", combined)
         self.assertIn("buildVerificationExtractEndpoint", groups_js)
         self.assertIn("source: 'temp'", temp_js)
         self.assertIn("copyVerificationInfo(currentAccount, buttonElement", emails_js)
@@ -447,17 +447,17 @@ if (typeof context.buildVerificationExtractEndpoint !== 'function') {
 }
 
 const tempResult = context.buildVerificationExtractEndpoint('demo+1@test.example', { source: 'temp-mail' });
-if (tempResult !== '/api/temp-emails/demo%2B1%40test.example/extract-verification') {
+if (tempResult !== '/api/temp-emails/demo%2B1%40test.example/verification') {
   throw new Error(`unexpected temp endpoint: ${tempResult}`);
 }
 
 const normalResult = context.buildVerificationExtractEndpoint('demo+1@test.example', { source: 'outlook' });
-if (normalResult !== '/api/emails/demo%2B1%40test.example/extract-verification') {
+if (normalResult !== '/api/emails/demo%2B1%40test.example/verification') {
   throw new Error(`unexpected normal endpoint: ${normalResult}`);
 }
 
 const defaultResult = context.buildVerificationExtractEndpoint('demo+1@test.example');
-if (defaultResult !== '/api/emails/demo%2B1%40test.example/extract-verification') {
+if (defaultResult !== '/api/emails/demo%2B1%40test.example/verification') {
   throw new Error(`unexpected default endpoint: ${defaultResult}`);
 }
 

--- a/tests/test_temp_mail_target_contract.py
+++ b/tests/test_temp_mail_target_contract.py
@@ -55,6 +55,57 @@ class TempMailTargetContractTests(unittest.TestCase):
         finally:
             resp.close()
 
+    def _create_temp_mail_message(
+        self,
+        email_addr: str,
+        content: str,
+        *,
+        message_id: str = "msg-1",
+        subject: str = "Verify your account",
+    ) -> None:
+        with self.app.app_context():
+            from outlook_web.repositories import temp_emails as temp_emails_repo
+
+            temp_emails_repo.create_temp_email(
+                email_addr=email_addr,
+                mailbox_type="user",
+                visible_in_ui=True,
+                source="custom_domain_temp_mail",
+            )
+            temp_emails_repo.save_temp_email_messages(
+                email_addr,
+                [
+                    {
+                        "id": message_id,
+                        "from_address": "noreply@example.com",
+                        "subject": subject,
+                        "content": content,
+                        "html_content": "",
+                        "timestamp": 1711111111,
+                    }
+                ],
+            )
+
+    def _gptmail_message_side_effect(
+        self,
+        content: str,
+        *,
+        message_id: str = "msg-1",
+        subject: str = "Verify your account",
+    ) -> list[dict[str, object]]:
+        message = {
+            "id": message_id,
+            "from_address": "noreply@example.com",
+            "subject": subject,
+            "content": content,
+            "html_content": "",
+            "timestamp": 1711111111,
+        }
+        return [
+            {"success": True, "data": {"emails": [message]}},
+            {"success": True, "data": message},
+        ]
+
     def test_temp_email_options_endpoint_returns_domain_and_prefix_rules(self):
         client = self.app.test_client()
         self._login(client)
@@ -135,6 +186,44 @@ class TempMailTargetContractTests(unittest.TestCase):
         self.assertIn("verification_code", data["data"])
         self.assertIn("verification_link", data["data"])
         self.assertIn("formatted", data["data"])
+
+    def test_temp_email_verification_field_code_returns_code_only(self):
+        content = "Code: 123456 https://verify.example/link"
+        self._create_temp_mail_message("codeonly@test.example", content)
+
+        client = self.app.test_client()
+        self._login(client)
+        with patch(
+            "outlook_web.services.gptmail.gptmail_request",
+            side_effect=self._gptmail_message_side_effect(content),
+        ):
+            resp = client.get(
+                "/api/temp-emails/codeonly@test.example/verification?field=code&code_length=6-6&code_source=content"
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json() or {}
+        data = payload.get("data") or {}
+        self.assertTrue(payload.get("success"))
+        self.assertEqual(data.get("verification_code"), "123456")
+        self.assertIsNone(data.get("verification_link"))
+        self.assertEqual(data.get("formatted"), "123456")
+
+    def test_temp_email_verification_field_code_404s_for_link_only_message(self):
+        content = "Use this verification link: https://verify.example/link"
+        self._create_temp_mail_message("linkonly@test.example", content)
+
+        client = self.app.test_client()
+        self._login(client)
+        with patch(
+            "outlook_web.services.gptmail.gptmail_request",
+            side_effect=self._gptmail_message_side_effect(content),
+        ):
+            resp = client.get("/api/temp-emails/linkonly@test.example/verification?field=code&code_source=content")
+
+        self.assertEqual(resp.status_code, 404)
+        payload = resp.get_json() or {}
+        self.assertFalse(payload.get("success"))
 
     def test_external_apply_endpoint_returns_hidden_task_mailbox(self):
         client = self.app.test_client()

--- a/tests/test_unified_verification_api.py
+++ b/tests/test_unified_verification_api.py
@@ -1,0 +1,64 @@
+"""ZER-90：统一 /verification API 契约测试。"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from tests._import_app import clear_login_attempts, import_web_app_module
+
+
+class UnifiedVerificationApiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = import_web_app_module()
+        cls.app = cls.module.app
+
+    def setUp(self):
+        with self.app.app_context():
+            clear_login_attempts()
+        self.client = self.app.test_client()
+
+    def _login(self):
+        resp = self.client.post("/login", json={"password": "testpass123"})
+        self.assertEqual(resp.status_code, 200)
+
+    @patch("outlook_web.controllers.emails.external_api_service.get_verification_result")
+    def test_verification_endpoint_aliases_extract_verification(self, mock_get_result):
+        self._login()
+        mock_get_result.return_value = {
+            "verification_code": "Ab12Cd",
+            "verification_link": "https://example.com/verify",
+            "formatted": "Ab12Cd https://example.com/verify",
+            "code_confidence": "high",
+            "link_confidence": "high",
+            "confidence": "high",
+            "folder": "inbox",
+            "matched_email_id": "msg-1",
+            "subject": "Code",
+            "from": "security@example.com",
+            "received_at": "2026-03-20T10:00:00Z",
+        }
+
+        with patch("outlook_web.controllers.emails.accounts_repo.get_account_by_email") as mock_account:
+            mock_account.return_value = {
+                "id": 1,
+                "email": "demo@example.com",
+                "account_type": "outlook",
+                "client_id": "cid",
+                "refresh_token": "rt",
+            }
+            with patch("outlook_web.controllers.emails.compact_summary_service.update_summary_from_verification") as mock_summary:
+                mock_summary.return_value = {"latest_verification_code": "Ab12Cd"}
+
+                resp = self.client.get("/api/emails/demo@example.com/verification?field=code")
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json() or {}
+        self.assertTrue(payload.get("success"))
+        self.assertEqual((payload.get("data") or {}).get("verification_code"), "Ab12Cd")
+        self.assertIsNone((payload.get("data") or {}).get("verification_link"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unified_verification_api.py
+++ b/tests/test_unified_verification_api.py
@@ -1,4 +1,4 @@
-"""ZER-90：统一 /verification API 契约测试。"""
+"""ZER-90: unified /verification API contract tests."""
 
 from __future__ import annotations
 
@@ -23,8 +23,23 @@ class UnifiedVerificationApiTests(unittest.TestCase):
         resp = self.client.post("/login", json={"password": "testpass123"})
         self.assertEqual(resp.status_code, 200)
 
+    def _get_with_outlook_account(self, path: str):
+        with patch("outlook_web.controllers.emails.accounts_repo.get_account_by_email") as mock_account:
+            mock_account.return_value = {
+                "id": 1,
+                "email": "demo@example.com",
+                "account_type": "outlook",
+                "client_id": "cid",
+                "refresh_token": "rt",
+            }
+            with patch(
+                "outlook_web.controllers.emails.compact_summary_service.update_summary_from_verification"
+            ) as mock_summary:
+                mock_summary.return_value = {"latest_verification_code": "Ab12Cd"}
+                return self.client.get(path)
+
     @patch("outlook_web.controllers.emails.external_api_service.get_verification_result")
-    def test_verification_endpoint_aliases_extract_verification(self, mock_get_result):
+    def test_verification_field_code_passes_expected_field_and_shapes_response(self, mock_get_result):
         self._login()
         mock_get_result.return_value = {
             "verification_code": "Ab12Cd",
@@ -40,24 +55,70 @@ class UnifiedVerificationApiTests(unittest.TestCase):
             "received_at": "2026-03-20T10:00:00Z",
         }
 
-        with patch("outlook_web.controllers.emails.accounts_repo.get_account_by_email") as mock_account:
-            mock_account.return_value = {
-                "id": 1,
-                "email": "demo@example.com",
-                "account_type": "outlook",
-                "client_id": "cid",
-                "refresh_token": "rt",
-            }
-            with patch("outlook_web.controllers.emails.compact_summary_service.update_summary_from_verification") as mock_summary:
-                mock_summary.return_value = {"latest_verification_code": "Ab12Cd"}
-
-                resp = self.client.get("/api/emails/demo@example.com/verification?field=code")
+        resp = self._get_with_outlook_account(
+            "/api/emails/demo@example.com/verification?field=code&code_length=6-6&code_source=content"
+        )
 
         self.assertEqual(resp.status_code, 200)
         payload = resp.get_json() or {}
+        data = payload.get("data") or {}
         self.assertTrue(payload.get("success"))
-        self.assertEqual((payload.get("data") or {}).get("verification_code"), "Ab12Cd")
-        self.assertIsNone((payload.get("data") or {}).get("verification_link"))
+        self.assertEqual(data.get("verification_code"), "Ab12Cd")
+        self.assertIsNone(data.get("verification_link"))
+        self.assertEqual(data.get("formatted"), "Ab12Cd")
+        self.assertEqual(mock_get_result.call_args.kwargs.get("expected_field"), "verification_code")
+        self.assertEqual(mock_get_result.call_args.kwargs.get("code_length"), "6-6")
+        self.assertEqual(mock_get_result.call_args.kwargs.get("code_source"), "content")
+
+    @patch("outlook_web.controllers.emails.external_api_service.get_verification_result")
+    def test_verification_field_code_requires_code_after_shaping(self, mock_get_result):
+        self._login()
+        mock_get_result.return_value = {
+            "verification_code": None,
+            "verification_link": "https://example.com/verify",
+            "formatted": "https://example.com/verify",
+            "code_confidence": "low",
+            "link_confidence": "high",
+            "confidence": "high",
+        }
+
+        resp = self._get_with_outlook_account("/api/emails/demo@example.com/verification?field=code")
+
+        self.assertEqual(resp.status_code, 404)
+        payload = resp.get_json() or {}
+        self.assertFalse(payload.get("success"))
+        self.assertEqual(mock_get_result.call_args.kwargs.get("expected_field"), "verification_code")
+
+    @patch("outlook_web.controllers.emails.external_api_service.get_verification_result")
+    def test_verification_field_link_passes_expected_field_and_shapes_response(self, mock_get_result):
+        self._login()
+        mock_get_result.return_value = {
+            "verification_code": "123456",
+            "verification_link": "https://example.com/verify",
+            "formatted": "123456 https://example.com/verify",
+            "code_confidence": "high",
+            "link_confidence": "high",
+            "confidence": "high",
+        }
+
+        resp = self._get_with_outlook_account("/api/emails/demo@example.com/verification?field=link")
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json() or {}
+        data = payload.get("data") or {}
+        self.assertIsNone(data.get("verification_code"))
+        self.assertEqual(data.get("verification_link"), "https://example.com/verify")
+        self.assertEqual(data.get("formatted"), "https://example.com/verify")
+        self.assertEqual(mock_get_result.call_args.kwargs.get("expected_field"), "verification_link")
+
+    @patch("outlook_web.controllers.emails.external_api_service.get_verification_result")
+    def test_verification_invalid_field_returns_400_without_extracting(self, mock_get_result):
+        self._login()
+
+        resp = self._get_with_outlook_account("/api/emails/demo@example.com/verification?field=otp")
+
+        self.assertEqual(resp.status_code, 400)
+        mock_get_result.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_v191_compact_mode_api_tdd.py
+++ b/tests/test_v191_compact_mode_api_tdd.py
@@ -317,6 +317,50 @@ class V191CompactModeApiRedTests(unittest.TestCase):
         self.assertEqual(row["latest_verification_folder"], "inbox")
         self.assertEqual(row["latest_verification_received_at"], "2026-03-20T09:58:00Z")
 
+    @patch("outlook_web.controllers.emails.graph_service.get_emails_graph")
+    def test_t_api_005d_fetch_emails_updates_latest_verification_with_mixed_case_code(self, mock_get_emails_graph):
+        client = self.app.test_client()
+        self._login(client)
+        group_id = self._create_group()
+        unique = uuid.uuid4().hex
+        email_addr = f"fetch_mixed_case_{unique}@example.com"
+        account_id = self._create_account(group_id=group_id, email_addr=email_addr)
+
+        mock_get_emails_graph.return_value = {
+            "success": True,
+            "emails": [
+                {
+                    "id": "msg-code",
+                    "subject": "Your verification code",
+                    "from": {"emailAddress": {"address": "security@example.com"}},
+                    "receivedDateTime": "2026-03-20T10:01:00Z",
+                    "bodyPreview": "Your verification code is Ab12Cd. It expires in 10 minutes.",
+                    "isRead": False,
+                    "hasAttachments": False,
+                }
+            ],
+        }
+
+        resp = client.get(f"/api/emails/{email_addr}?folder=inbox&skip=0&top=20")
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json() or {}
+        self.assertEqual(payload.get("success"), True)
+        account_summary = payload.get("account_summary") or {}
+        self.assertEqual(account_summary.get("latest_verification_code"), "Ab12Cd")
+
+        conn = self._db()
+        try:
+            row = conn.execute(
+                "SELECT latest_verification_code FROM accounts WHERE id = ?",
+                (account_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row["latest_verification_code"], "Ab12Cd")
+
     def test_t_api_005b_accounts_api_does_not_fetch_remote_mail_during_list_render(self):
         client = self.app.test_client()
         self._login(client)

--- a/tests/test_v191_compact_mode_frontend_contract.py
+++ b/tests/test_v191_compact_mode_frontend_contract.py
@@ -125,6 +125,13 @@ class V191CompactModeFrontendContractTests(unittest.TestCase):
         ]:
             self.assertIn(field, compact_js)
 
+    def test_compact_verification_copy_uses_unified_extractor(self):
+        client = self.app.test_client()
+        compact_js = self._get_text(client, "/static/js/features/mailbox_compact.js")
+
+        self.assertIn("return copyVerificationInfo(account.email, buttonElement);", compact_js)
+        self.assertNotIn("copyToClipboard(account.latest_verification_code)", compact_js)
+
     def test_compact_mode_exposes_server_pagination_controls(self):
         client = self.app.test_client()
         compact_js = self._get_text(client, "/static/js/features/mailbox_compact.js")

--- a/tests/test_v191_compact_mode_frontend_contract.py
+++ b/tests/test_v191_compact_mode_frontend_contract.py
@@ -132,6 +132,13 @@ class V191CompactModeFrontendContractTests(unittest.TestCase):
         self.assertIn("return copyVerificationInfo(account.email, buttonElement);", compact_js)
         self.assertNotIn("copyToClipboard(account.latest_verification_code)", compact_js)
 
+    def test_groups_js_uses_unified_verification_endpoint(self):
+        client = self.app.test_client()
+        groups_js = self._get_text(client, "/static/js/features/groups.js")
+
+        self.assertIn("/verification", groups_js)
+        self.assertIn("buildVerificationExtractEndpoint", groups_js)
+
     def test_compact_mode_exposes_server_pagination_controls(self):
         client = self.app.test_client()
         compact_js = self._get_text(client, "/static/js/features/mailbox_compact.js")

--- a/tests/test_verification_channel_memory_v1.py
+++ b/tests/test_verification_channel_memory_v1.py
@@ -151,6 +151,76 @@ class VerificationChannelMemoryV1Tests(unittest.TestCase):
             "body": {"content": body_text, "contentType": "text"},
         }
 
+    def test_expected_field_code_skips_newer_link_only_message(self):
+        with self.app.app_context():
+            from outlook_web.services import verification_channel_routing as vcr
+
+            fake_account = {
+                "id": 10,
+                "email": "expected@outlook.com",
+                "account_type": "outlook",
+                "provider": "outlook",
+                "group_id": None,
+                "preferred_verification_channel": None,
+                "client_id": "cid",
+                "refresh_token": "rt",
+            }
+            emails = [
+                {
+                    "id": "link-msg",
+                    "subject": "Verify with link",
+                    "date": "2026-04-19T10:01:00Z",
+                    "body_preview": "Click the verification link",
+                },
+                {
+                    "id": "code-msg",
+                    "subject": "Your code",
+                    "date": "2026-04-19T10:00:00Z",
+                    "body_preview": "Your code is 123456",
+                },
+            ]
+
+            def detail_for_message(*, message_id: str, **_kwargs):
+                body_text = (
+                    "Use this verification link: https://verify.example/link"
+                    if message_id == "link-msg"
+                    else "Your verification code is 123456"
+                )
+                return {
+                    "id": message_id,
+                    "subject": "Verification",
+                    "from": {"emailAddress": {"address": "noreply@example.com"}},
+                    "receivedDateTime": "2026-04-19T10:00:00Z",
+                    "body": {"content": body_text, "contentType": "text"},
+                }
+
+            with (
+                patch.object(vcr, "build_verification_channel_plan", return_value=["graph_inbox"]),
+                patch.object(vcr.channel_capability_cache, "filter_channel_plan", return_value=["graph_inbox"]),
+                patch.object(
+                    vcr,
+                    "fetch_emails_and_detail_for_channel",
+                    return_value={"success": True, "emails": emails},
+                ),
+                patch.object(vcr, "fetch_email_detail_for_channel", side_effect=detail_for_message) as mock_detail,
+                patch(
+                    "outlook_web.services.graph.get_access_token_graph_result",
+                    return_value={"success": True, "scope": "Mail.Read"},
+                ),
+                patch("outlook_web.services.graph.has_mail_read_permission", return_value=True),
+            ):
+                result = vcr.extract_verification_for_outlook(
+                    account=fake_account,
+                    resolved_policy={"code_regex": None, "code_length": "6-6"},
+                    code_source="all",
+                    expected_field="verification_code",
+                )
+
+            self.assertTrue(result.get("success"))
+            self.assertEqual((result.get("data") or {}).get("matched_email_id"), "code-msg")
+            self.assertEqual((result.get("data") or {}).get("verification_code"), "123456")
+            self.assertEqual(mock_detail.call_count, 2)
+
     @patch("outlook_web.services.graph.get_emails_graph")
     @patch("outlook_web.services.imap.get_email_detail_imap_with_server")
     @patch("outlook_web.services.imap.get_emails_imap_with_server")

--- a/tests/test_verification_code_extraction.py
+++ b/tests/test_verification_code_extraction.py
@@ -1,0 +1,86 @@
+"""ZER-90：统一验证码提取模块测试。"""
+
+from __future__ import annotations
+
+import unittest
+
+from outlook_web.services.verification_code_extraction import (
+    VerificationInput,
+    VerificationPolicy,
+    apply_confidence_gate,
+    extract_verification,
+    extract_verification_from_email_dict,
+)
+
+
+class VerificationCodeExtractionModuleTests(unittest.TestCase):
+    def test_extract_lowercase_alphanumeric_code_with_policy_length(self):
+        email = VerificationInput(subject="Your verification code", body="Your verification code is ab12cd")
+        policy = VerificationPolicy(code_length="6-6", code_source="all")
+
+        result = extract_verification(email, policy)
+
+        self.assertEqual(result.get("verification_code"), "ab12cd")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+    def test_extract_preserves_mixed_case(self):
+        email = VerificationInput(body="Your verification code is Ab12Cd")
+        policy = VerificationPolicy(code_length="6-6")
+
+        result = extract_verification(email, policy)
+
+        self.assertEqual(result.get("verification_code"), "Ab12Cd")
+
+    def test_extract_html_ignores_css_color_and_keeps_hyphen_code(self):
+        email = VerificationInput(
+            subject="Verification",
+            body_html=(
+                "<html><head><style>.title { color: #333333; }</style></head><body>"
+                "<p>Your verification code is 84A-KMN</p>"
+                "</body></html>"
+            ),
+        )
+        policy = VerificationPolicy(code_length="6-6", code_source="all")
+
+        result = extract_verification(email, policy)
+
+        self.assertEqual(result.get("verification_code"), "84A-KMN")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+    def test_apply_confidence_gate_strips_low_confidence_code(self):
+        raw = {
+            "verification_code": "123456",
+            "verification_link": None,
+            "code_confidence": "low",
+            "link_confidence": "low",
+        }
+        gated = apply_confidence_gate(raw, enforce_mutual_exclusion=False)
+        self.assertIsNone(gated.get("verification_code"))
+
+    def test_expected_field_code_filters_link(self):
+        email = VerificationInput(
+            body="Your verification code is 123456 https://example.com/verify",
+        )
+        policy = VerificationPolicy(code_length="6-6", expected_field="code")
+
+        result = extract_verification(email, policy)
+
+        self.assertEqual(result.get("verification_code"), "123456")
+        self.assertIsNone(result.get("verification_link"))
+        self.assertEqual(result.get("formatted"), "123456")
+
+    def test_legacy_wrapper_matches_unified_extractor(self):
+        email = {
+            "subject": "Validate your email",
+            "body": "Please use the code below to validate your email address.\n\n84A-KMN",
+        }
+
+        unified = extract_verification(VerificationInput.from_email_dict(email), VerificationPolicy())
+        legacy = extract_verification_from_email_dict(email)
+
+        self.assertEqual(legacy.get("verification_code"), unified.get("verification_code"))
+        self.assertEqual(legacy.get("code_confidence"), unified.get("code_confidence"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verification_extractor.py
+++ b/tests/test_verification_extractor.py
@@ -413,6 +413,122 @@ class TestVerificationExtractor(unittest.TestCase):
         text = extract_email_text(email)
         self.assertIn("555666", text)
 
+    # ==================== 大小写保持测试（回归） ====================
+
+    def test_smart_extract_preserves_lowercase(self):
+        """
+        测试用例：智能识别 - 保持小写验证码原样
+
+        测试目的：验证智能识别不再私自转换大小写（含数字的小写字母验证码）
+        """
+        content = "Your verification code is ab12cd. Please verify."
+        result = smart_extract_verification_code(content)
+        self.assertEqual(result, "ab12cd")
+
+    def test_smart_extract_preserves_mixed_case(self):
+        """
+        测试用例：智能识别 - 保持大小写混合验证码原样
+        """
+        content = "您的验证码是 Ab12Cd，请尽快使用。"
+        result = smart_extract_verification_code(content)
+        self.assertEqual(result, "Ab12Cd")
+
+    def test_fallback_extract_preserves_lowercase(self):
+        """
+        测试用例：保底提取 - 保持小写验证码原样
+        """
+        content = "Please use ab12cd to complete your registration."
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "ab12cd")
+
+    def test_fallback_extract_preserves_mixed_case(self):
+        """
+        测试用例：保底提取 - 保持大小写混合验证码原样
+        """
+        content = "Please use Ab12Cd to complete your registration."
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "Ab12Cd")
+
+    def test_extract_verification_info_preserves_case(self):
+        """
+        测试用例：完整流程 - verification_code 与 formatted 均保持原大小写
+        """
+        email = {"body": "Your verification code is ab12cd."}
+        result = extract_verification_info_from_text(email["body"])
+        self.assertEqual(result["verification_code"], "ab12cd")
+        self.assertEqual(result["formatted"], "ab12cd")
+
+    # ==================== 带连字符验证码（x.ai）测试 ====================
+
+    def test_smart_extract_xai_hyphenated_code(self):
+        """x.ai 邮件：关键词附近应识别 84A-KMN。"""
+        content = (
+            "Thank you for creating an xAI account. " "Please use the code below to validate your email address.\n\n84A-KMN"
+        )
+        result = smart_extract_verification_code(content)
+        self.assertEqual(result, "84A-KMN")
+
+    def test_fallback_extract_xai_hyphenated_code_with_context(self):
+        """x.ai 邮件：无紧邻关键词时，凭验证码语境应识别 84A-KMN。"""
+        content = (
+            "Validate your email\n"
+            "Thank you for creating an xAI account. "
+            "Please use the code below to validate your email address.\n\n"
+            "84A-KMN\n"
+            "© 2026 X.AI LLC\n"
+            "For questions contact support@x.ai"
+        )
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "84A-KMN")
+
+    def test_hyphenated_code_not_extracted_without_context(self):
+        """无验证码语境时，不应把订单号样式的连字符串当成验证码。"""
+        content = "Your order reference AB-12 has shipped. Tracking ID: XY-99-ZZ."
+        result = fallback_extract_verification_code(content)
+        self.assertIsNone(result)
+
+    def test_fallback_extract_xai_glued_hyphenated_code(self):
+        """x.ai HTML 解析后验证码可能与英文句首粘连（84A-KMNIf）。"""
+        content = (
+            "Thank you for creating an xAI account. "
+            "Please use the code below to validate your email address.84A-KMNIf "
+            "you did not create a new account, please ignore this email."
+        )
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "84A-KMN")
+
+    def test_fallback_extract_xai_all_letter_hyphenated_code(self):
+        """x.ai 真实邮件可能为全字母连字符验证码（如 NJF-KUU）。"""
+        content = (
+            "Thank you for creating an xAI account. "
+            "Please use the code below to validate your email address.\n\n"
+            "NJF-KUU\n\n"
+            "if you did not create a new account, please ignore this email.\n"
+            "SpaceXAI Team\n"
+            "© 2026 X.AI LLC\n"
+            "For questions contact support@x.ai"
+        )
+        result = fallback_extract_verification_code(content)
+        self.assertEqual(result, "NJF-KUU")
+
+    def test_extract_verification_info_xai_email_without_ai(self):
+        """ZER-57 回归：未开启 AI 时也应从 x.ai 邮件提取验证码。"""
+        email = {
+            "subject": "Validate your email",
+            "body": (
+                "Hi,\n\n"
+                "Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.\n\n"
+                "84A-KMN\n\n"
+                "If you did not create a new account, please ignore this email.\n\n"
+                "SpaceXAI Team\n"
+                "© 2026 X.AI LLC\n"
+                "For questions contact support@x.ai"
+            ),
+        }
+        result = extract_verification_info(email)
+        self.assertEqual(result["verification_code"], "84A-KMN")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verification_extractor_options.py
+++ b/tests/test_verification_extractor_options.py
@@ -35,6 +35,32 @@ class VerificationExtractorOptionsTests(unittest.TestCase):
         self.assertEqual(result.get("verification_code"), "654321")
         self.assertIsNone(result.get("verification_link"))
 
+    def test_extract_with_code_length_supports_lowercase_alphanumeric_code(self):
+        func = self._require_new_api()
+        email = {
+            "subject": "Your verification code",
+            "body": "Your verification code is ab12cd",
+            "body_html": "",
+        }
+
+        result = func(email, code_length="6-6")
+
+        self.assertEqual(result.get("verification_code"), "ab12cd")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+    def test_extract_with_code_length_preserves_mixed_case_alphanumeric_code(self):
+        func = self._require_new_api()
+        email = {
+            "subject": "Your verification code",
+            "body": "Your verification code is Ab12Cd",
+            "body_html": "",
+        }
+
+        result = func(email, code_length="6-6")
+
+        self.assertEqual(result.get("verification_code"), "Ab12Cd")
+        self.assertEqual(result.get("code_confidence"), "high")
+
     def test_extract_with_code_regex_supports_alphanumeric_code(self):
         func = self._require_new_api()
         email = {
@@ -510,6 +536,96 @@ class VerificationExtractorConfidenceTests(unittest.TestCase):
             "low",
             "'verify your purchase' 不应触发链接验证语境提权",
         )
+
+    def test_extract_xai_hyphenated_code_without_ai(self):
+        """ZER-57：默认规则路径应识别 x.ai 带连字符验证码，且置信度为 high。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "Validate your email",
+            "body": (
+                "Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.\n\n"
+                "84A-KMN\n\n"
+                "© 2026 X.AI LLC"
+            ),
+            "body_html": "",
+        }
+        result = func(email)
+        self.assertEqual(result.get("verification_code"), "84A-KMN")
+        self.assertEqual(result.get("code_confidence"), "high")
+
+    def test_apply_confidence_gate_keeps_xai_hyphenated_code(self):
+        """门控后 x.ai 带连字符验证码仍应保留。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "Validate your email",
+            "body": "Please use the code below to validate your email address.\n\n84A-KMN",
+            "body_html": "",
+        }
+        extracted = func(email)
+        gated = extractor.apply_confidence_gate(extracted, enforce_mutual_exclusion=False)
+        self.assertEqual(gated.get("verification_code"), "84A-KMN")
+
+    def test_extract_xai_all_letter_hyphenated_code_njf_kuu(self):
+        """ZER-57 真实收信样本：全字母验证码 NJF-KUU。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "xAI confirmation",
+            "body": (
+                "Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.\n\n"
+                "NJF-KUU\n\n"
+                "if you did not create a new account, please ignore this email.\n"
+                "SpaceXAI Team\n"
+                "© 2026 X.AI LLC\n"
+                "For questions contact support@x.ai"
+            ),
+            "body_html": "",
+        }
+        result = func(email)
+        self.assertEqual(result.get("verification_code"), "NJF-KUU")
+        self.assertEqual(result.get("code_confidence"), "high")
+        gated = extractor.apply_confidence_gate(result, enforce_mutual_exclusion=False)
+        self.assertEqual(gated.get("verification_code"), "NJF-KUU")
+
+    def test_extract_xai_html_with_css_color_false_positive(self):
+        """x.ai HTML 邮件含 #333333 样式色值时，不应误提取为验证码。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "NJF-KUU xAI confirmation code",
+            "body": "",
+            "body_html": (
+                "<html><head><style>.title { color: #333333; }</style></head><body>"
+                "<p>Thank you for creating an xAI account. "
+                "Please use the code below to validate your email address.</p>"
+                "<p>NJF-KUU</p>"
+                "<p>For questions contact support@x.ai</p>"
+                "</body></html>"
+            ),
+        }
+        result = func(email, code_source="all")
+        self.assertEqual(result.get("verification_code"), "NJF-KUU")
+        self.assertEqual(result.get("code_confidence"), "high")
+        gated = extractor.apply_confidence_gate(result, enforce_mutual_exclusion=False)
+        self.assertEqual(gated.get("verification_code"), "NJF-KUU")
+
+    def test_extract_html_ignores_css_color_and_keeps_context_hyphen_code(self):
+        """ZER-90: HTML 样式色值 #333333 不应覆盖正文里的 84A-KMN。"""
+        func = self._require_new_api()
+        email = {
+            "subject": "Verification",
+            "body": "",
+            "body_html": (
+                "<html><head><style>.title { color: #333333; }</style></head><body>"
+                "<p>Your verification code is 84A-KMN</p>"
+                "</body></html>"
+            ),
+        }
+
+        result = func(email, code_source="all")
+
+        self.assertEqual(result.get("verification_code"), "84A-KMN")
+        self.assertEqual(result.get("code_confidence"), "high")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

将 ZER-90 验证码提取能力收敛为独立统一模块，并补齐前端统一调用接口。本 PR 在 #118 修复基础上完成架构层收敛。

## Changes

### 统一提取模块 `verification_code_extraction.py`
- 新增 `VerificationPolicy` / `VerificationInput` 数据模型
- 提供 `extract_verification()` 作为唯一规则提取入口
- 收敛候选生成、HTML 可见文本解析、连字符验证码、置信度门控等逻辑
- `verification_extractor.py` 退化为兼容壳层 + AI 回退层，旧函数签名保持不变

### 简洁模式摘要
- `account_compact_summary` 改为调用统一模块
- 按账号所属组解析 `code_length` / `code_regex` 策略（不再硬编码 `6-6`）
- 继续应用置信度门控，与标准模式一致

### 前端统一接口
- 新增 `GET /api/emails/<email>/verification`（及临时邮箱 `/api/temp-emails/<email>/verification`）
- 支持 `field=code|link|any`、`code_source`、`code_length`、`code_regex`
- 保留 `/extract-verification` 向后兼容
- `copyVerificationInfo()` 默认改调 `/verification`

## Test plan
- [x] `tests/test_verification_code_extraction.py` — 模块级大小写/HTML/连字符/门控
- [x] `tests/test_unified_verification_api.py` — 新 API 与 field 过滤
- [x] `tests/test_verification_extractor.py` + `test_verification_extractor_options.py` — 兼容层回归
- [x] `tests/test_v191_compact_mode_*` — 简洁模式 API/前端契约
- [x] `tests/test_temp_mail_target_contract.py` — 临时邮箱前端端点更新

Closes ZER-90
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://chatgpt-a1a4278.slack.com/archives/C0BDF94JZEE/p1784080035363759?thread_ts=1784080035.363759&cid=C0BDF94JZEE)

<div><a href="https://cursor.com/agents/bc-76dea7bf-91a2-5f58-8a0d-f2df33cc5cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76dea7bf-91a2-5f58-8a0d-f2df33cc5cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

