### PR TITLE
fix: show invalid-token governance actions from manual entry

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3133,6 +3133,9 @@ ${details}
                     return;
                 }
 
+                // 手动入口只会调用本加载函数，因此有候选时必须同步显示治理操作区。
+                showInvalidTokenDetectionSummary(count, invalidTokenGovernanceCandidates);
+
                 // 渲染候选列表
                 const listEl = document.getElementById('invalidTokenCandidateList');
                 const listWrap = document.getElementById('invalidTokenCandidateListWrap');

--- a/tests/test_invalid_token_governance_frontend_contract.py
+++ b/tests/test_invalid_token_governance_frontend_contract.py
@@ -1,0 +1,24 @@
+"""失效 Token 治理手动入口的前端回归测试。"""
+
+import unittest
+from pathlib import Path
+
+
+class InvalidTokenGovernanceFrontendContractTests(unittest.TestCase):
+    def test_manual_governance_loader_reveals_action_summary(self):
+        """手动加载到候选后必须显示包含治理按钮的摘要区。"""
+        repo_root = Path(__file__).resolve().parents[1]
+        main_js = (repo_root / "static" / "js" / "main.js").read_text(encoding="utf-8")
+        loader_start = main_js.index("async function loadInvalidTokenGovernanceCandidates")
+        loader_end = main_js.index("/** 批量将失效 Token 候选账号置为停用 */", loader_start)
+        loader_source = main_js[loader_start:loader_end]
+
+        self.assertIn(
+            "showInvalidTokenDetectionSummary(count, invalidTokenGovernanceCandidates);",
+            loader_source,
+            "手动失效治理入口加载到候选后没有显示治理操作区",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Show the invalid-token governance summary and action buttons whenever the manual governance loader returns candidates.
- Add a frontend regression contract covering the manual-entry path.

## Root cause

The manual “失效治理” entry loaded and rendered invalid-token candidates, but it only made the outer container and candidate list visible. The batch deactivate/delete buttons live inside `invalidTokenSummary`, which remained hidden because `showInvalidTokenDetectionSummary()` was only called by refresh-result paths.

As a result, users could see detected invalid accounts but could not trigger any governance action from the manual entry.

## Impact

Opening “失效治理” now displays the candidate count together with the batch deactivate and delete actions. Existing backend behavior and automatic refresh handling are unchanged.

## Validation

- `python -m unittest tests.test_invalid_token_governance tests.test_invalid_token_governance_frontend_contract -v` — 13 tests passed in the built image.
- `node --check static/js/main.js`
- Built and ran the Docker image locally; container health check passed.
- Verified the real browser flow: login → token refresh modal → manual “失效治理”; 24 candidates were shown and both governance buttons were visible.
