### PR TITLE
[codex] fix(auth): request offline_access during token refresh

### DIFF
--- a/outlook_web/services/graph.py
+++ b/outlook_web/services/graph.py
@@ -11,6 +11,7 @@ from outlook_web.services.http import get_response_details
 TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
 TOKEN_URL_GRAPH = TOKEN_URL_TEMPLATE.format(tenant="common")
 DEFAULT_GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+DEFAULT_REFRESH_SCOPE = f"{DEFAULT_GRAPH_SCOPE} offline_access"
 GRAPH_MAIL_READ_SCOPES = ("Mail.Read", "Mail.ReadWrite")
 
 # Graph API 返回 401 时表示账号授权失效（与 token endpoint 失败不同）
@@ -266,7 +267,7 @@ def test_refresh_token_with_rotation(
     proxy_url: str = None,
     *,
     tenant: str = "common",
-    scope: str = DEFAULT_GRAPH_SCOPE,
+    scope: str = DEFAULT_REFRESH_SCOPE,
     max_retries: int = 3,
 ) -> tuple[bool, str | None, str | None]:
     """测试 refresh token 是否有效；如服务端返回新的 refresh_token，则一并返回（用于滚动更新）。
@@ -274,7 +275,7 @@ def test_refresh_token_with_rotation(
     import time
 
     proxies = build_proxies(proxy_url)
-    resolved_scope = (scope or DEFAULT_GRAPH_SCOPE).strip() or DEFAULT_GRAPH_SCOPE
+    resolved_scope = (scope or DEFAULT_REFRESH_SCOPE).strip() or DEFAULT_REFRESH_SCOPE
     url = build_token_url(tenant)
     data = {
         "client_id": client_id,

--- a/tests/test_graph_permission_precheck.py
+++ b/tests/test_graph_permission_precheck.py
@@ -102,6 +102,20 @@ class TestGraphPermissionPrecheck(unittest.TestCase):
         self.assertFalse(result.get("success"))
         self.assertIsNone(result.get("scope"))
 
+    @patch("outlook_web.services.graph.requests.post")
+    def test_refresh_token_request_includes_offline_access(self, mock_post):
+        """刷新请求必须申请可滚动更新的 refresh token。"""
+        from outlook_web.services.graph import test_refresh_token_with_rotation
+
+        mock_post.return_value = _make_graph_token_response("at-123", refresh_token="rt-new")
+
+        success, error_message, new_refresh_token = test_refresh_token_with_rotation("cid", "rt-old")
+
+        self.assertTrue(success)
+        self.assertIsNone(error_message)
+        self.assertEqual(new_refresh_token, "rt-new")
+        self.assertIn("offline_access", mock_post.call_args.kwargs["data"]["scope"].split())
+
     # ------------------------------------------------------------------
     # get_emails_graph 跳过无权限调用
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Pull request type / PR 类型

- [x] Bugfix / Bug 修复
- [ ] Feature / 新功能
- [ ] Code style update (formatting, renaming) / 代码风格更新（格式化、重命名）
- [ ] Refactoring (no functional changes, no api changes) / 重构（无功能更改、无 API 更改）
- [ ] Build related changes / 构建相关更改
- [ ] Documentation content changes / 文档内容更改
- [ ] Other (please describe) / 其他（请描述）:

## What is the current behavior? / 当前行为是什么？

Issue Number / Issue 编号: N/A

账号管理的全量刷新以 `https://graph.microsoft.com/.default` 作为默认 scope 请求 Microsoft token endpoint，未显式请求 `offline_access`。因此响应可以成功返回 access token，但不返回新的 `refresh_token`；后端只更新刷新时间，导出仍读到旧的 refresh token。

## What is the new behavior? / 新行为是什么？

- 仅 token 刷新函数的默认 scope 现在包含 `offline_access`，允许 Microsoft 返回轮换后的 refresh token。
- 显式传入的自定义 scope 保持不变；邮件读取等其他 Graph token 请求不受影响。
- 新增回归测试，断言默认刷新请求实际发送 `offline_access`。

## Release notes / 发布日志

修复：账号全量刷新 Token 时会请求 `offline_access`，使新的 refresh token 能够被接收、持久化并在导出中使用。

## Other information / 其他信息

验证已完成：

- `python -m unittest discover -s tests -p test_graph_permission_precheck.py`（10 passed）
- `python -m unittest discover -s tests -p test_refresh_outlook_only.py`（10 passed）
- `python -m unittest discover -s tests -p test_export_enhanced_v2.py`（7 passed）
- `git diff --check`
