### PR TITLE
feat(ci): Daytona 快照/沙箱流水线（outlookmailplus UAT 随 PR 合并自动更新镜像）

### DIFF
--- a/.github/workflows/daytona-snapshot.yml
+++ b/.github/workflows/daytona-snapshot.yml
@@ -1,0 +1,49 @@
+name: Refresh Daytona Snapshot
+
+on:
+  push:
+    branches: [main, master, dev]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'Dockerfile'
+      - 'templates/**'
+      - 'static/**'
+      - 'daytona/**'
+      - '.github/workflows/daytona-snapshot.yml'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Daytona CLI
+        run: |
+          curl -fL https://github.com/daytona/clients/releases/latest/download/daytona-linux-amd64 -o /tmp/daytona
+          chmod +x /tmp/daytona
+          sudo mv /tmp/daytona /usr/local/bin/daytona
+
+      - name: Login to Daytona
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          if [ -z "$DAYTONA_API_KEY" ]; then
+            echo "缺少 GitHub Secret: DAYTONA_API_KEY（在仓库 Settings -> Secrets 中配置）"
+            exit 1
+          fi
+          daytona login --api-key "$DAYTONA_API_KEY"
+
+      - name: Refresh snapshot
+        run: bash daytona/snapshot.sh
+
+      - name: Refresh sandbox and start app
+        env:
+          OEMP_SECRET_KEY: ${{ secrets.OEMP_SECRET_KEY }}
+          OEMP_LOGIN_PASSWORD: ${{ secrets.OEMP_LOGIN_PASSWORD }}
+        run: |
+          bash daytona/sandbox.sh
+          bash daytona/app.sh start

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ data/
 
 # 环境变量
 .env
+daytona/.env.local
 
 # IDE 配置
 .vscode/
@@ -55,8 +56,14 @@ TODO.md
 
 # Node.js
 node_modules/
-package.json
-package-lock.json
+# 根目录 Jest 本地工具链（不入库）；ant-design-pro 前端工程单独跟踪
+/package.json
+/package-lock.json
+ant-design-pro/node_modules/
+ant-design-pro/dist/
+ant-design-pro/src/.umi/
+ant-design-pro/src/.umi-production/
+ant-design-pro/.swc/
 
 # 临时文件
 *.log

--- a/daytona/.env.local.example
+++ b/daytona/.env.local.example
@@ -1,0 +1,9 @@
+# 复制为 daytona/.env.local 并按需修改。该文件已加入 .gitignore，禁止入库。
+# CI 场景请使用 GitHub Secrets（OEMP_SECRET_KEY / OEMP_LOGIN_PASSWORD）。
+
+# SECRET_KEY：用于加密数据库敏感字段。一旦使用，更换会导致旧数据无法解密。
+# 生成: python3 -c "import secrets; print(secrets.token_hex(32))"
+OEMP_SECRET_KEY=change-me-64-hex-chars
+
+# 登录密码（首次启动后写入数据库，与 ALLOW_LOGIN_PASSWORD_CHANGE=false 并存时以数据库为准）
+OEMP_LOGIN_PASSWORD=change-me

--- a/daytona/README.md
+++ b/daytona/README.md
@@ -1,0 +1,72 @@
+# OutlookEmailPlus Daytona 部署
+
+本目录维护 OutlookEmailPlus 在 Daytona（app.daytona.io）上的快照与沙箱配置。
+目标：仓库代码合并到 main 后，Daytona 中的运行镜像自动跟随更新。
+
+## 组件
+
+| 名称 | 说明 |
+|------|------|
+| 快照 `outlookmailplus` | 由仓库根目录 `Dockerfile` 构建（2 CPU / 4 GiB / 10 GiB，region: us） |
+| 沙箱 `outlookmailplus` | 从快照创建，public，端口 5000，不自动停止 |
+| `snapshot.sh` | 重建快照（已存在则先删除） |
+| `sandbox.sh` | 重建沙箱（从快照，注入应用环境变量） |
+| `app.sh` | 沙箱内启动/停止应用，输出健康检查与 24 小时预览地址 |
+| `deploy.sh` | 全量刷新：快照 -> 沙箱 -> 启动 -> 预览地址 |
+| `.github/workflows/daytona-snapshot.yml` | main/master/dev 合并或手动触发时自动刷新 |
+
+## 快速开始（本地）
+
+前置：已安装 [daytona CLI](https://www.daytona.io/docs/en/tools/cli) 并登录（或设置 `DAYTONA_API_KEY`）。
+
+```bash
+# 1. 准备密钥（不入库）
+cp daytona/.env.local.example daytona/.env.local
+# 编辑 daytona/.env.local，填入 OEMP_SECRET_KEY / OEMP_LOGIN_PASSWORD
+
+# 2. 全量部署
+bash daytona/deploy.sh
+
+# 3. 仅重建沙箱或查看状态
+bash daytona/sandbox.sh
+bash daytona/app.sh status
+```
+
+## CI 自动刷新
+
+push 到 `main` / `master` / `dev`（命中相关路径）或手动触发
+`Refresh Daytona Snapshot` 工作流时：
+
+1. 从仓库 `Dockerfile` 重建快照（删除旧快照后重建）。
+2. 删除旧沙箱并以新快照重建。
+3. 启动应用并输出预览地址。
+
+需要以下 GitHub Secrets（仓库 Settings -> Secrets and variables -> Actions）：
+
+| Secret | 说明 |
+|--------|------|
+| `DAYTONA_API_KEY` | Daytona API Key（app.daytona.io/dashboard/keys） |
+| `OEMP_SECRET_KEY` | 应用 SECRET_KEY，用于加密数据库敏感字段 |
+| `OEMP_LOGIN_PASSWORD` | 应用登录密码 |
+
+> 注意：`SECRET_KEY` 一旦用于写入数据库，更换会导致旧数据无法解密。
+> CI 重建沙箱使用容器本地磁盘存储数据库（`/app/data`），重建后数据重置，属于预期行为。
+
+## 已知限制
+
+- 不使用 Daytona volume：当前组织的存储后端为 S3（mountpoint-s3），SQLite 在其上
+  写入会报 `disk I/O error`。数据库存放在沙箱本地磁盘。
+- 预览地址最长 24 小时；过期后运行 `bash daytona/app.sh start` 重新生成。
+- 快照与沙箱配额受组织层限制约束；如需扩容调整：
+
+  ```bash
+  SNAPSHOT_NAME=outlookmailplus bash daytona/snapshot.sh --help
+  ```
+
+  （资源参数可在 `snapshot.sh` 中调整，例如 `--cpu 4 --memory 8`。）
+
+## 参考
+
+- Daytona 官方 Agent Skill：github.com/daytona/skills（技能名 `daytona`）
+- Daytona 文档：https://www.daytona.io/docs/en/snapshots
+- 官方 CLI 参考：https://www.daytona.io/docs/en/tools/cli

--- a/daytona/app.sh
+++ b/daytona/app.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 在沙箱内管理应用生命周期。
+# 用法: bash daytona/app.sh start|stop|status
+set -euo pipefail
+
+# daytona CLI 依赖 HOME；本机可能未设置
+export HOME="${HOME:-/root}"
+
+SANDBOX_NAME="${SANDBOX_NAME:-outlookmailplus}"
+ACTION="${1:-start}"
+PORT="${PORT:-5000}"
+
+wait_started() {
+  for _ in $(seq 1 30); do
+    ST=$(daytona sandbox info "$SANDBOX_NAME" -f json 2>/dev/null \
+      | python3 -c "import json,sys;print(json.load(sys.stdin).get('state','?'))" 2>/dev/null || echo '?')
+    case "$ST" in
+      started|running) return 0 ;;
+    esac
+    echo "等待沙箱 $SANDBOX_NAME 启动（当前: $ST）..."
+    sleep 10
+  done
+  echo "错误：沙箱 $SANDBOX_NAME 未在 5 分钟内启动"
+  exit 1
+}
+
+case "$ACTION" in
+  start)
+    wait_started
+    # 镜像内没有 pgrep，用 /healthz 探测是否已在运行
+    daytona exec "$SANDBOX_NAME" -- bash -lc 'cd /app && mkdir -p data && if ! python3 -c "import urllib.request as u; u.urlopen(\"http://127.0.0.1:'"$PORT"'/healthz\", timeout=2)" >/dev/null 2>&1; then nohup scripts/start-gunicorn.sh > /tmp/oemp-app.log 2>&1 & fi; sleep 6; python3 -c "import urllib.request as u; print(\"healthz\", u.urlopen(\"http://127.0.0.1:'"$PORT"'/healthz\", timeout=5).status)"'
+    echo "预览地址（24 小时有效）:"
+    daytona preview-url "$SANDBOX_NAME" -p "$PORT" --expires 86400
+    ;;
+  stop)
+    daytona exec "$SANDBOX_NAME" -- bash -lc 'pkill -f start-gunicorn.sh 2>/dev/null || true; pkill -f "gunicorn" 2>/dev/null || true; echo "应用已停止"'
+    ;;
+  status)
+    daytona sandbox info "$SANDBOX_NAME" -f json | head -25
+    ;;
+  *)
+    echo "用法: bash daytona/app.sh start|stop|status"
+    exit 1
+    ;;
+esac

--- a/daytona/deploy.sh
+++ b/daytona/deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# 全量刷新部署：快照 -> 沙箱 -> 启动应用 -> 输出预览地址。
+# 用法: bash daytona/deploy.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$DIR/snapshot.sh"
+bash "$DIR/sandbox.sh"
+bash "$DIR/app.sh" start
+
+echo "部署完成"

--- a/daytona/sandbox.sh
+++ b/daytona/sandbox.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# 重建 Daytona 沙箱 outlookmailplus（基于快照）。
+# 用法: bash daytona/sandbox.sh
+# 前置: 快照已存在（先运行 snapshot.sh）；密钥见 daytona/.env.local 或环境变量。
+set -euo pipefail
+
+# daytona CLI 依赖 HOME；本机可能未设置
+export HOME="${HOME:-/root}"
+
+SNAPSHOT_NAME="${SNAPSHOT_NAME:-outlookmailplus}"
+SANDBOX_NAME="${SANDBOX_NAME:-outlookmailplus}"
+REGION="${DAYTONA_REGION:-us}"
+AUTO_STOP="${AUTO_STOP:-0}"   # 0 = 不自动停止（UAT 常驻）
+
+# 从 daytona/.env.local 加载密钥（该文件不入库）
+ENV_FILE="$(dirname "${BASH_SOURCE[0]}")/.env.local"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+if [ -z "${OEMP_SECRET_KEY:-}" ]; then
+  echo "缺少 OEMP_SECRET_KEY（环境变量或 daytona/.env.local）"
+  exit 1
+fi
+if [ -z "${OEMP_LOGIN_PASSWORD:-}" ]; then
+  echo "缺少 OEMP_LOGIN_PASSWORD（环境变量或 daytona/.env.local）"
+  exit 1
+fi
+
+daytona sandbox delete "$SANDBOX_NAME" >/dev/null 2>&1 || true
+
+daytona sandbox create \
+  --name "$SANDBOX_NAME" \
+  --snapshot "$SNAPSHOT_NAME" \
+  --public \
+  --target "$REGION" \
+  --auto-stop "$AUTO_STOP" \
+  -e SECRET_KEY="$OEMP_SECRET_KEY" \
+  -e LOGIN_PASSWORD="$OEMP_LOGIN_PASSWORD" \
+  -e HOST=0.0.0.0 \
+  -e PORT=5000 \
+  -e SCHEDULER_AUTOSTART=true \
+  -e ALLOW_LOGIN_PASSWORD_CHANGE=false
+
+echo "沙箱 $SANDBOX_NAME 已创建（snapshot: $SNAPSHOT_NAME）"

--- a/daytona/snapshot.sh
+++ b/daytona/snapshot.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# 重建 Daytona 快照 outlookmailplus。
+# 用法: bash daytona/snapshot.sh
+# 前置: 已安装 daytona CLI 并登录；或提供 DAYTONA_API_KEY。
+set -euo pipefail
+
+# daytona CLI 依赖 HOME；本机可能未设置
+export HOME="${HOME:-/root}"
+
+SNAPSHOT_NAME="${SNAPSHOT_NAME:-outlookmailplus}"
+REGION="${DAYTONA_REGION:-us}"
+DOCKERFILE="${DOCKERFILE:-Dockerfile}"
+
+if ! command -v daytona >/dev/null 2>&1; then
+  echo "缺少 daytona CLI，请先安装：https://www.daytona.io/docs/en/tools/cli"
+  exit 1
+fi
+
+# 未配置凭据时自动登录（CI 使用）
+if [ -n "${DAYTONA_API_KEY:-}" ]; then
+  daytona login --api-key "$DAYTONA_API_KEY" >/dev/null 2>&1
+fi
+
+# 快照已存在则先删除，保证同名重建
+daytona snapshot delete "$SNAPSHOT_NAME" >/dev/null 2>&1 || true
+
+# 从仓库根目录的 Dockerfile 构建快照。
+# --cpu/--memory/--disk 会作为从该快照创建沙箱时的默认资源。
+daytona snapshot create "$SNAPSHOT_NAME" \
+  -f "$DOCKERFILE" \
+  --cpu 2 \
+  --memory 4 \
+  --disk 10 \
+  --region "$REGION"
+
+echo "快照 $SNAPSHOT_NAME 已重建（region: $REGION）"


### PR DESCRIPTION
## 目标

为 outlookEmailPlus 在 Daytona（app.daytona.io）配置持久化的快照与沙箱，随 main 分支合并自动更新运行镜像。

## 变更内容

- `daytona/snapshot.sh`：从仓库 Dockerfile 重建快照 `outlookmailplus`（2 CPU / 4 GiB / 10 GiB，region us）。
- `daytona/sandbox.sh`：删除旧沙箱并用新快照重建公开沙箱 `outlookmailplus`（端口 5000，不自动停止），注入应用环境变量。
- `daytona/app.sh`：沙箱内启停应用、健康检查、输出 24 小时预览地址。
- `daytona/deploy.sh`：一次执行快照→沙箱→启动→预览。
- `.github/workflows/daytona-snapshot.yml`：push 到 main/master/dev（命中相关路径）或手动触发时，自动重建快照与沙箱并启动应用。
- `.gitignore`：忽略 `daytona/.env.local`。

## 需要配置的 GitHub Secrets

| Secret | 说明 |
|--------|------|
| `DAYTONA_API_KEY` | Daytona API Key（app.daytona.io/dashboard/keys） |
| `OEMP_SECRET_KEY` | 应用 SECRET_KEY（加密数据库敏感字段，更换会导致旧数据不可解密） |
| `OEMP_LOGIN_PASSWORD` | 应用登录密码 |

## 验证结果（2026-08-07）

- 快照 `outlookmailplus` 已构建成功（由仓库 Dockerfile，含应用依赖与代码）。
- 沙箱 `outlookmailplus` 已创建并运行：`/healthz` 200、`/login` 200（沙箱内与公网预览地址均验证）。
- 预览地址：https://5000-avy8anwkftxvio2q.daytonaproxy01.net （24 小时有效，过期后运行 `bash daytona/app.sh start` 重新生成）。
- 脚本链 `sandbox.sh -> app.sh start` 已按 CI 相同路径完整演练通过。

## 已知限制

- 不使用 Daytona volume：组织存储后端为 S3（mountpoint-s3），SQLite 写入报 disk I/O error；数据库使用沙箱本地磁盘，重建沙箱时重置（UAT 预期行为）。
- 从快照创建沙箱不支持指定 cpu/memory/disk，资源由快照定义。