### PR TITLE
fix(ci): snapshot 重建失败重试（解决 delete/create 竞态）

### DIFF
--- a/daytona/snapshot.sh
+++ b/daytona/snapshot.sh
@@ -21,16 +21,32 @@ if [ -n "${DAYTONA_API_KEY:-}" ]; then
   daytona login --api-key "$DAYTONA_API_KEY" >/dev/null 2>&1
 fi
 
-# 快照已存在则先删除，保证同名重建
-daytona snapshot delete "$SNAPSHOT_NAME" >/dev/null 2>&1 || true
+# 快照已存在则先删除（"未找到"属预期，忽略；其余错误先记录再继续）
+DELETE_OUT="$(daytona snapshot delete "$SNAPSHOT_NAME" 2>&1 || true)"
+if [ -n "$DELETE_OUT" ] && ! echo "$DELETE_OUT" | grep -qi "not found"; then
+  echo "删除旧快照提示: $DELETE_OUT"
+fi
 
 # 从仓库根目录的 Dockerfile 构建快照。
 # --cpu/--memory/--disk 会作为从该快照创建沙箱时的默认资源。
-daytona snapshot create "$SNAPSHOT_NAME" \
-  -f "$DOCKERFILE" \
-  --cpu 2 \
-  --memory 4 \
-  --disk 10 \
-  --region "$REGION"
+# 删除与创建之间可能有一致性窗口（同名冲突），做有限重试。
+CREATE_OK=0
+for attempt in 1 2 3 4 5; do
+  if daytona snapshot create "$SNAPSHOT_NAME" \
+    -f "$DOCKERFILE" \
+    --cpu 2 \
+    --memory 4 \
+    --disk 10 \
+    --region "$REGION" >/tmp/daytona-snapshot-create.log 2>&1; then
+    CREATE_OK=1
+    break
+  fi
+  echo "快照创建失败（第 $attempt 次），10 秒后重试..."
+  sleep 10
+done
+if [ "$CREATE_OK" -ne 1 ]; then
+  cat /tmp/daytona-snapshot-create.log
+  exit 1
+fi
 
 echo "快照 $SNAPSHOT_NAME 已重建（region: $REGION）"


### PR DESCRIPTION
## 问题

PR #126 合并触发 CI 后，`Refresh Daytona Snapshot` 在 `daytona snapshot create` 失败：`Conflict: Snapshot with name outlookmailplus already exists`。

根因：删除旧快照与重建之间有一致性窗口（旧快照记录暂未消失），一次性创建撞名。

## 修复

`daytona/snapshot.sh`：
- 删除旧快照时保留输出信息（仅忽略 not found）
- 创建快照最多重试 5 次，每次间隔 10 秒，失败时输出日志并退出非 0

## 验证

修复后手动重新触发工作流（workflow_dispatch）验证全链路。