### PR TITLE
fix(frontend): 登录后拒绝跳转到已移除路由 (ZER-534)

### DIFF
--- a/ant-design-pro/package-lock.json
+++ b/ant-design-pro/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ant-design-pro",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ant-design-pro",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dependencies": {
         "@ant-design/icons": "^6.3.1",
         "@ant-design/pro-components": "^3.1.12-0",

--- a/ant-design-pro/package.json
+++ b/ant-design-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-design-pro",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "private": true,
   "description": "OutlookEmail Plus SPA frontend (Ant Design Pro)",
   "repository": "git@github.com:ZeroPointSix/outlookEmailPlus.git",

--- a/ant-design-pro/src/pages/user/login/index.tsx
+++ b/ant-design-pro/src/pages/user/login/index.tsx
@@ -6,23 +6,8 @@ import { createStyles } from 'antd-style';
 import React, { startTransition, useState } from 'react';
 import { Footer } from '@/components';
 import { login } from '@/services/outlook/auth';
+import { getSafeRedirectUrl } from '@/utils/authRedirect';
 import Settings from '../../../../config/defaultSettings';
-
-/**
- * Validate redirect URL to prevent open redirect attacks.
- * Only allow same-origin relative paths starting with '/'.
- */
-const getSafeRedirectUrl = (redirect: string | null): string => {
-  if (!redirect?.startsWith('/')) return '/accounts';
-  if (redirect.startsWith('//')) return '/accounts';
-  try {
-    const parsed = new URL(redirect, window.location.origin);
-    if (parsed.origin !== window.location.origin) return '/accounts';
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
-  } catch {
-    return '/accounts';
-  }
-};
 
 const useStyles = createStyles(({ token }) => {
   return {
@@ -104,7 +89,10 @@ const Login: React.FC = () => {
         );
         await fetchUserInfo();
         const urlParams = new URL(window.location.href).searchParams;
-        const redirectUrl = getSafeRedirectUrl(urlParams.get('redirect'));
+        const redirectUrl = getSafeRedirectUrl(
+          urlParams.get('redirect'),
+          window.location.origin,
+        );
         window.location.href = redirectUrl;
         return;
       }

--- a/ant-design-pro/src/utils/authRedirect.test.ts
+++ b/ant-design-pro/src/utils/authRedirect.test.ts
@@ -1,0 +1,53 @@
+import routes from '../../config/routes';
+import {
+  AUTHENTICATED_ROUTE_PATHS,
+  DEFAULT_AUTHENTICATED_REDIRECT,
+  getSafeRedirectUrl,
+} from './authRedirect';
+
+const ORIGIN = 'https://mail.example.com';
+
+describe('getSafeRedirectUrl', () => {
+  it.each([
+    null,
+    '',
+    'https://evil.example.com/accounts',
+    '//evil.example.com/accounts',
+    '/\\evil.example.com/accounts',
+    '/',
+    '/dashboard',
+    '/user/login',
+    '/accounts-extra',
+  ])('falls back for an invalid or removed route: %s', (redirect) => {
+    expect(getSafeRedirectUrl(redirect, ORIGIN)).toBe(
+      DEFAULT_AUTHENTICATED_REDIRECT,
+    );
+  });
+
+  it.each(AUTHENTICATED_ROUTE_PATHS)(
+    'allows the authenticated route %s',
+    (route) => {
+      expect(getSafeRedirectUrl(route, ORIGIN)).toBe(route);
+    },
+  );
+
+  it('preserves query parameters and hash for a valid route', () => {
+    expect(
+      getSafeRedirectUrl('/accounts/?filter=active#account-42', ORIGIN),
+    ).toBe('/accounts?filter=active#account-42');
+  });
+
+  it('stays in sync with the configured authenticated routes', () => {
+    const configuredPaths = routes
+      .map((route) => route.path)
+      .filter(
+        (path): path is string =>
+          typeof path === 'string' &&
+          path !== '/' &&
+          path !== '/user' &&
+          path !== '*',
+      );
+
+    expect(configuredPaths).toEqual(AUTHENTICATED_ROUTE_PATHS);
+  });
+});

--- a/ant-design-pro/src/utils/authRedirect.ts
+++ b/ant-design-pro/src/utils/authRedirect.ts
@@ -1,0 +1,45 @@
+export const DEFAULT_AUTHENTICATED_REDIRECT = '/overview';
+
+export const AUTHENTICATED_ROUTE_PATHS = [
+  '/overview',
+  '/mailbox',
+  '/accounts',
+  '/groups',
+  '/temp-emails',
+  '/pool-admin',
+  '/plugins',
+  '/refresh-log',
+  '/settings',
+  '/audit',
+  '/token-tool',
+] as const;
+
+const AUTHENTICATED_ROUTE_PATH_SET = new Set<string>(
+  AUTHENTICATED_ROUTE_PATHS,
+);
+
+export const getSafeRedirectUrl = (
+  redirect: string | null,
+  origin: string,
+): string => {
+  if (!redirect?.startsWith('/') || redirect.startsWith('//')) {
+    return DEFAULT_AUTHENTICATED_REDIRECT;
+  }
+
+  try {
+    const parsed = new URL(redirect, origin);
+    if (parsed.origin !== origin) return DEFAULT_AUTHENTICATED_REDIRECT;
+
+    const pathname =
+      parsed.pathname.length > 1
+        ? parsed.pathname.replace(/\/+$/, '')
+        : parsed.pathname;
+    if (!AUTHENTICATED_ROUTE_PATH_SET.has(pathname)) {
+      return DEFAULT_AUTHENTICATED_REDIRECT;
+    }
+
+    return `${pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return DEFAULT_AUTHENTICATED_REDIRECT;
+  }
+};


### PR DESCRIPTION
## 根因

未登录访问任意路径时，认证守卫会把当前路径写入 `redirect`。登录页此前只校验目标是否为同源相对路径，因此旧书签（如 `/dashboard`）也会被保留，登录成功后进入 SPA 404。

## 修复

- 仅允许跳转到当前配置的 11 个已认证业务路由
- 未知、已移除、登录页、外部或协议相对地址统一回退到 `/overview`
- 合法路由继续保留 query 和 hash，并规范化尾部斜杠
- 新增路由清单与 `config/routes.ts` 的同步测试
- 前端版本及 lockfile 同步升级至 `6.0.3`

## 验证

- [通过] Node 24 纯函数冒烟：21 个断言通过
- [通过] 覆盖 `/dashboard`、`/user/login`、外链、协议相对地址、全部业务路由、query/hash
- [通过] GitHub Actions `Run tests with coverage`：连续两次通过
- [外部阻塞] SonarQube Scan：连续两次在 SonarCloud 读取 PR `130` 时失败（`Something went wrong while trying to get the pullrequest with key '130'`，exit 3），不是代码扫描结果
- [未运行] 本 PR 的非标准 base 分支未触发 Docker/frontend workflow；沙箱与 npm registry 在本次执行环境不可用，因此未运行完整 Vitest、TypeScript、lint 与 build

Linear: ZER-534