### PR TITLE
ci: verify Utoopack compatibility for ZER-582

### DIFF
--- a/.github/workflows/zer-582-builder-compat.yml
+++ b/.github/workflows/zer-582-builder-compat.yml
@@ -1,0 +1,60 @@
+name: ZER-582 builder compatibility probe
+
+on:
+  push:
+    branches:
+      - delivery/zer-582-utoopack-compat-20260810
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ant-design-pro
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Environment
+        run: |
+          set -euxo pipefail
+          uname -a
+          node --version
+          npm --version
+          wc -c package-lock.json
+          node -p "require('./package.json').devDependencies['@umijs/max']"
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts=false --no-audit --no-fund
+
+      - name: Resolve builder versions
+        run: |
+          set -euxo pipefail
+          node -p "'UMI=' + require('@umijs/max/package.json').version"
+          node -p "'UTOO=' + require('@utoo/pack/package.json').version"
+          node -e "require('@utoo/pack'); console.log('UTOO_REQUIRE_OK')"
+
+      - name: Type check
+        run: npm run tsc
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Production build
+        run: npm run build
+
+      - name: Verify artifact
+        run: |
+          set -euxo pipefail
+          test -f dist/index.html
+          du -sh dist

--- a/.github/workflows/zer-582-builder-compat.yml
+++ b/.github/workflows/zer-582-builder-compat.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - delivery/zer-582-utoopack-compat-20260810
+  pull_request:
+    branches:
+      - feat/ant-design-pro-frontend-migration
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
仅添加临时诊断工作流，用 GitHub-hosted Ubuntu + Node 22 对迁移分支执行依赖安装、类型检查、单元测试和生产构建。不会部署，也不修改业务代码。完成验证后再决定是否保留 Utoopack 或切换构建器。