### PR TITLE
fix(zer-658): 生产环境隐藏开发态主题抽屉并新增正式主题入口

### DIFF
--- a/ant-design-pro/src/app.tsx
+++ b/ant-design-pro/src/app.tsx
@@ -17,7 +17,13 @@ import {
   GithubLink,
   LangDropdown,
   OfflineBanner,
+  ThemeToggle,
 } from '@/components';
+import {
+  loadPersistedNavTheme,
+  persistNavTheme,
+  type AppNavTheme,
+} from '@/components/RightContent/ThemeToggle';
 import {
   ensureCsrfToken,
   type OutlookCurrentUser,
@@ -68,18 +74,23 @@ export async function getInitialState(): Promise<{
   };
   // 如果不是登录页面，执行
   const { location } = history;
+  // 主题优先级：localStorage 持久化偏好 > 默认设置（ZER-658）
+  const initialSettings = {
+    ...defaultSettings,
+    navTheme: loadPersistedNavTheme(defaultSettings.navTheme as AppNavTheme),
+  } as Partial<LayoutSettings>;
   if (![loginPath].includes(location.pathname)) {
     const currentUser = await fetchUserInfo();
     return {
       fetchUserInfo,
       currentUser,
-      settings: defaultSettings as Partial<LayoutSettings>,
+      settings: initialSettings,
       settingDrawerOpen: false,
     };
   }
   return {
     fetchUserInfo,
-    settings: defaultSettings as Partial<LayoutSettings>,
+    settings: initialSettings,
     settingDrawerOpen: false,
   };
 }
@@ -107,6 +118,17 @@ export const layout: RunTimeLayoutConfig = ({
         (initialState?.settings as { locale?: boolean })?.locale !== false;
       return [
         <GithubLink key="github" />,
+        <ThemeToggle
+          key="theme"
+          navTheme={initialState?.settings?.navTheme as AppNavTheme | undefined}
+          onChange={(theme) => {
+            persistNavTheme(theme);
+            setInitialState((s) => ({
+              ...s,
+              settings: { ...s?.settings, navTheme: theme },
+            }));
+          }}
+        />,
         localeEnabled && <LangDropdown key="lang" />,
       ].filter(Boolean);
     },
@@ -149,24 +171,28 @@ export const layout: RunTimeLayoutConfig = ({
       return (
         <>
           {children}
-          <SettingDrawer
-            disableUrlParams
-            enableDarkTheme
-            collapse={initialState?.settingDrawerOpen}
-            onCollapseChange={(open) => {
-              setInitialState((s) => ({
-                ...s,
-                settingDrawerOpen: open,
-              }));
-            }}
-            settings={initialState?.settings}
-            onSettingChange={(settings) => {
-              setInitialState((s) => ({
-                ...s,
-                settings,
-              }));
-            }}
-          />
+          {/* ZER-658：开发态设置抽屉仅在开发环境渲染；
+              生产环境使用右上角正式主题切换入口 */}
+          {isDev && (
+            <SettingDrawer
+              disableUrlParams
+              enableDarkTheme
+              collapse={initialState?.settingDrawerOpen}
+              onCollapseChange={(open) => {
+                setInitialState((s) => ({
+                  ...s,
+                  settingDrawerOpen: open,
+                }));
+              }}
+              settings={initialState?.settings}
+              onSettingChange={(settings) => {
+                setInitialState((s) => ({
+                  ...s,
+                  settings,
+                }));
+              }}
+            />
+          )}
         </>
       );
     },

--- a/ant-design-pro/src/components/RightContent/AvatarDropdown.tsx
+++ b/ant-design-pro/src/components/RightContent/AvatarDropdown.tsx
@@ -9,6 +9,9 @@ import { Spin } from 'antd';
 import React, { startTransition } from 'react';
 import { outLogin } from '@/services/outlook/auth';
 import HeaderDropdown from '../HeaderDropdown';
+import { persistNavTheme } from './ThemeToggle';
+
+const isDev = process.env.NODE_ENV === 'development';
 
 type GlobalHeaderRightProps = {
   children?: React.ReactNode;
@@ -70,7 +73,19 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
       return;
     }
     if (key === 'theme') {
-      setInitialState((s) => ({ ...s, settingDrawerOpen: true }));
+      // ZER-658：生产环境没有开发态抽屉，菜单项直接切换浅色/深色；
+      // 开发环境保留打开 SettingDrawer 的行为。
+      if (isDev) {
+        setInitialState((s) => ({ ...s, settingDrawerOpen: true }));
+      } else {
+        const current = initialState?.settings?.navTheme;
+        const next = current === 'realDark' ? 'light' : 'realDark';
+        persistNavTheme(next);
+        setInitialState((s) => ({
+          ...s,
+          settings: { ...s?.settings, navTheme: next },
+        }));
+      }
       return;
     }
     if (key === 'settings') {

--- a/ant-design-pro/src/components/RightContent/ThemeToggle.test.ts
+++ b/ant-design-pro/src/components/RightContent/ThemeToggle.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  THEME_STORAGE_KEY,
+  loadPersistedNavTheme,
+  persistNavTheme,
+} from './ThemeToggle';
+
+describe('ThemeToggle persistence (ZER-658)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('无存储值时回退到默认浅色', () => {
+    expect(loadPersistedNavTheme()).toBe('light');
+    expect(loadPersistedNavTheme('realDark')).toBe('realDark');
+  });
+
+  it('持久化后可读回深色偏好', () => {
+    persistNavTheme('realDark');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('realDark');
+    expect(loadPersistedNavTheme()).toBe('realDark');
+  });
+
+  it('非法存储值回退到默认值', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'purple');
+    expect(loadPersistedNavTheme()).toBe('light');
+  });
+
+  it('localStorage 不可用时静默回退', () => {
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('unavailable');
+    });
+    expect(loadPersistedNavTheme()).toBe('light');
+
+    vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('unavailable');
+    });
+    expect(() => persistNavTheme('realDark')).not.toThrow();
+  });
+});

--- a/ant-design-pro/src/components/RightContent/ThemeToggle.tsx
+++ b/ant-design-pro/src/components/RightContent/ThemeToggle.tsx
@@ -1,0 +1,56 @@
+import { MoonOutlined, SunOutlined } from '@ant-design/icons';
+import type { Settings as LayoutSettings } from '@ant-design/pro-components';
+import { Button, Tooltip } from 'antd';
+import React from 'react';
+
+export const THEME_STORAGE_KEY = 'outlook.navTheme';
+
+export type AppNavTheme = Exclude<LayoutSettings['navTheme'], undefined>;
+
+/**
+ * 读取持久化的主题偏好；非法值回退到默认浅色。
+ */
+export function loadPersistedNavTheme(fallback: AppNavTheme = 'light'): AppNavTheme {
+  try {
+    const saved = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (saved === 'light' || saved === 'realDark') {
+      return saved;
+    }
+  } catch (_error) {
+    // localStorage 不可用（隐私模式等）时静默回退
+  }
+  return fallback;
+}
+
+export function persistNavTheme(theme: AppNavTheme) {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (_error) {
+    // 忽略持久化失败，不影响当次切换
+  }
+}
+
+type ThemeToggleProps = {
+  navTheme?: AppNavTheme;
+  onChange?: (theme: AppNavTheme) => void;
+};
+
+/**
+ * 正式的主题切换入口：仅暴露浅色 / 深色两个产品选项，
+ * 不包含布局、固定侧栏等开发态设置（ZER-658）。
+ */
+const ThemeToggle: React.FC<ThemeToggleProps> = ({ navTheme, onChange }) => {
+  const isDark = navTheme === 'realDark';
+  return (
+    <Tooltip title={isDark ? '切换到浅色模式' : '切换到深色模式'}>
+      <Button
+        type="text"
+        aria-label={isDark ? '切换到浅色模式' : '切换到深色模式'}
+        icon={isDark ? <MoonOutlined /> : <SunOutlined />}
+        onClick={() => onChange?.(isDark ? 'light' : 'realDark')}
+      />
+    </Tooltip>
+  );
+};
+
+export default ThemeToggle;

--- a/ant-design-pro/src/components/RightContent/index.tsx
+++ b/ant-design-pro/src/components/RightContent/index.tsx
@@ -1,4 +1,5 @@
 import GithubLink from './GithubLink';
 import { LangDropdown } from './LangDropdown';
+import ThemeToggle from './ThemeToggle';
 
-export { GithubLink, LangDropdown };
+export { GithubLink, LangDropdown, ThemeToggle };

--- a/ant-design-pro/src/components/index.ts
+++ b/ant-design-pro/src/components/index.ts
@@ -6,7 +6,7 @@
  * 布局组件
  */
 import Footer from './Footer';
-import { GithubLink, LangDropdown } from './RightContent';
+import { GithubLink, LangDropdown, ThemeToggle } from './RightContent';
 import { AvatarDropdown } from './RightContent/AvatarDropdown';
 
 /**
@@ -15,4 +15,4 @@ import { AvatarDropdown } from './RightContent/AvatarDropdown';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as OfflineBanner } from './OfflineBanner';
 
-export { AvatarDropdown, Footer, GithubLink, LangDropdown };
+export { AvatarDropdown, Footer, GithubLink, LangDropdown, ThemeToggle };


### PR DESCRIPTION
## 问题（ZER-658）

`app.tsx` 的 `childrenRender` 无条件渲染 Ant Design Pro `SettingDrawer`，`isDev` 只用于控制旧版前端链接，生产环境暴露开发态设置抽屉；且头像菜单「主题设置」在生产环境会打开该抽屉。

## 修复

- `SettingDrawer` 仅在开发环境（`NODE_ENV === 'development'`）渲染
- 新增 `ThemeToggle` 组件：右上角正式中文主题入口，仅暴露浅色/深色两个产品选项
- 主题偏好持久化 localStorage，启动时恢复
- 头像菜单「主题设置」：开发环境打开抽屉；生产环境直接切换浅色/深色（消除死按钮）

## 验收对照

- [x] 生产环境不渲染 SettingDrawer（生产构建产物已验证）
- [x] 开发环境保留面板
- [x] 正式中文主题入口，支持浅色/深色
- [x] 只暴露产品允许的选项
- [x] 主题选择可持久化（4 项单测）
- [x] 生产构建无可见开发态设置入口（build 0 error，产物 grep 无死路径）

## 测试

- biome lint ✅ / tsc ✅ / vitest 105/105 ✅ / 生产构建 ✅

Closes ZER-658