### PR TITLE
feat(zer-653): 新前端账号标签能力——展示/筛选/打标/标签管理

### DIFF
--- a/ant-design-pro/src/pages/accounts/index.tsx
+++ b/ant-design-pro/src/pages/accounts/index.tsx
@@ -6,6 +6,7 @@ import {
   PlusOutlined,
   ReloadOutlined,
   SyncOutlined,
+  TagsOutlined,
 } from '@ant-design/icons';
 import {
   ModalForm,
@@ -24,6 +25,7 @@ import { useIntl } from '@umijs/max';
 import {
   App,
   Button,
+  Dropdown,
   Form,
   Input,
   Modal,
@@ -63,6 +65,14 @@ import {
   type GroupItem,
 } from '@/services/outlook/groups';
 import {
+  batchManageAccountTags,
+  createTag,
+  deleteTag as deleteTagApi,
+  fetchTags,
+  serializeTagIds,
+  type TagItem,
+} from '@/services/outlook/tags';
+import {
   ACCOUNT_STATUS_OPTIONS,
   accountStatusLabel,
   refreshStatusLabel,
@@ -75,6 +85,18 @@ const statusColor = (status?: string) => {
   if (s === 'error' || s === 'failed') return 'error';
   return 'processing';
 };
+
+/** 把后端 tags 字段归一化成 TagItem[]（兼容字符串形态） */
+const normalizeTags = (
+  tags?: Array<{ id?: number; name?: string; color?: string } | string>,
+): TagItem[] =>
+  (tags || []).map((t) =>
+    typeof t === 'string' ? { id: 0, name: t } : {
+      id: Number(t.id || 0),
+      name: String(t.name || ''),
+      color: t.color,
+    },
+  );
 
 const AccountsPage: React.FC = () => {
   const { message, modal } = App.useApp();
@@ -94,6 +116,10 @@ const AccountsPage: React.FC = () => {
   const [exporting, setExporting] = useState(false);
   const [refreshAllRunning, setRefreshAllRunning] = useState(false);
   const refreshAllRunningRef = useRef(false);
+  const [tagManagerOpen, setTagManagerOpen] = useState(false);
+  const [newTagName, setNewTagName] = useState('');
+  const [newTagColor, setNewTagColor] = useState('#1677ff');
+  const [tagCreating, setTagCreating] = useState(false);
 
   const groupsQuery = useQuery({
     queryKey: ['groups'],
@@ -103,6 +129,22 @@ const AccountsPage: React.FC = () => {
     queryKey: ['providers'],
     queryFn: fetchProviders,
   });
+  const tagsQuery = useQuery({
+    queryKey: ['tags'],
+    queryFn: fetchTags,
+  });
+  const tags: TagItem[] = useMemo(
+    () => tagsQuery.data?.tags || [],
+    [tagsQuery.data],
+  );
+  const tagOptions = useMemo(
+    () =>
+      tags.map((t) => ({
+        label: t.name,
+        value: t.id,
+      })),
+    [tags],
+  );
 
   const normalGroups = useMemo(() => {
     return (groupsQuery.data?.groups || []).filter(
@@ -228,6 +270,37 @@ const AccountsPage: React.FC = () => {
       ),
     },
     {
+      title: '标签',
+      dataIndex: 'tags',
+      width: 180,
+      search: false,
+      render: (_, row) => {
+        const list = normalizeTags(row.tags);
+        if (!list.length) return '--';
+        return (
+          <Space size={4} wrap>
+            {list.map((t, idx) => (
+              <Tag key={t.id || `${t.name}-${idx}`} color={t.color}>
+                {t.name}
+              </Tag>
+            ))}
+          </Space>
+        );
+      },
+    },
+    {
+      title: '标签筛选',
+      dataIndex: 'tag_ids',
+      valueType: 'select',
+      hideInTable: true,
+      fieldProps: {
+        mode: 'multiple',
+        placeholder: '按标签筛选',
+        options: tagOptions,
+        loading: tagsQuery.isLoading,
+      },
+    },
+    {
       title: '备注',
       dataIndex: 'remark',
       ellipsis: true,
@@ -253,7 +326,7 @@ const AccountsPage: React.FC = () => {
     {
       title: '操作',
       valueType: 'option',
-      width: 240,
+      width: 300,
       render: (_, row) => [
         <Button
           key="mailbox"
@@ -263,6 +336,27 @@ const AccountsPage: React.FC = () => {
         >
           邮件
         </Button>,
+        <Dropdown
+          key="tags"
+          menu={{
+            items: tags.length
+              ? tags.map((t) => {
+                  const has = normalizeTags(row.tags).some(
+                    (x) => x.id === t.id,
+                  );
+                  return {
+                    key: String(t.id),
+                    label: `${has ? '✓ ' : '+ '}${t.name}`,
+                    onClick: () => void onToggleRowTag(row, t),
+                  };
+                })
+              : [{ key: 'empty', label: '暂无标签，请先在标签管理中新建', disabled: true }],
+          }}
+        >
+          <Button type="link" icon={<TagsOutlined />}>
+            打标
+          </Button>
+        </Dropdown>,
         <Button
           key="edit"
           type="link"
@@ -327,6 +421,79 @@ const AccountsPage: React.FC = () => {
       actionRef.current?.reload();
     } catch (error: any) {
       message.error(error?.message || '通知切换失败');
+    }
+  };
+
+  // 行内打标：已有该标签则移除，没有则添加
+  const onToggleRowTag = async (row: AccountItem, tag: TagItem) => {
+    const has = normalizeTags(row.tags).some((t) => t.id === tag.id);
+    try {
+      const res = await batchManageAccountTags(
+        [row.id],
+        tag.id,
+        has ? 'remove' : 'add',
+      );
+      if (res?.success === false) {
+        message.error(pickAccountErrorMessage(res, '标签操作失败'));
+        return;
+      }
+      message.success(res.message || (has ? '已移除标签' : '已添加标签'));
+      actionRef.current?.reload();
+    } catch (error: any) {
+      message.error(error?.message || '标签操作失败');
+    }
+  };
+
+  const runBatchTag = async (tagId: number, action: 'add' | 'remove') => {
+    const tag = tags.find((t) => t.id === tagId);
+    if (!tag) return;
+    await runBatch(
+      `${action === 'add' ? '为选中账号添加' : '从选中账号移除'}标签「${tag.name}」？`,
+      async () => {
+        const res = await batchManageAccountTags(selectedIds, tagId, action);
+        if (res?.success === false) {
+          throw new Error(pickAccountErrorMessage(res, '标签操作失败'));
+        }
+        message.success(res.message || '标签操作完成');
+      },
+    );
+  };
+
+  const onCreateTag = async () => {
+    const name = newTagName.trim();
+    if (!name) {
+      message.warning('请输入标签名称');
+      return;
+    }
+    setTagCreating(true);
+    try {
+      const res = await createTag(name, newTagColor);
+      if (res?.success === false) {
+        message.error(pickAccountErrorMessage(res, '标签创建失败'));
+        return;
+      }
+      message.success(res.message || '标签创建成功');
+      setNewTagName('');
+      await tagsQuery.refetch();
+    } catch (error: any) {
+      message.error(error?.message || '标签创建失败');
+    } finally {
+      setTagCreating(false);
+    }
+  };
+
+  const onDeleteTag = async (tagId: number) => {
+    try {
+      const res = await deleteTagApi(tagId);
+      if (res?.success === false) {
+        message.error(pickAccountErrorMessage(res, '标签删除失败'));
+        return;
+      }
+      message.success(res.message || '标签已删除');
+      await tagsQuery.refetch();
+      actionRef.current?.reload();
+    } catch (error: any) {
+      message.error(error?.message || '标签删除失败');
     }
   };
 
@@ -594,6 +761,26 @@ const AccountsPage: React.FC = () => {
             >
               关通知
             </Button>
+            <Select
+              size="small"
+              placeholder="添加标签"
+              style={{ width: 140 }}
+              options={tagOptions}
+              value={null}
+              onChange={(tagId: number | undefined) => {
+                if (tagId != null) void runBatchTag(tagId, 'add');
+              }}
+            />
+            <Select
+              size="small"
+              placeholder="移除标签"
+              style={{ width: 140 }}
+              options={tagOptions}
+              value={null}
+              onChange={(tagId: number | undefined) => {
+                if (tagId != null) void runBatchTag(tagId, 'remove');
+              }}
+            />
             <Button
               size="small"
               icon={<SyncOutlined />}
@@ -717,6 +904,13 @@ const AccountsPage: React.FC = () => {
                 actionRef.current?.reload();
               }}
             />,
+            <Button
+              key="tag-manager"
+              icon={<TagsOutlined />}
+              onClick={() => setTagManagerOpen(true)}
+            >
+              标签管理
+            </Button>,
           ],
         }}
         request={async (params) => {
@@ -726,6 +920,9 @@ const AccountsPage: React.FC = () => {
               page_size: params.pageSize || 20,
               search: (params.email as string) || undefined,
               group_id: groupId,
+              tag_ids: serializeTagIds(
+                Array.isArray(params.tag_ids) ? params.tag_ids : undefined,
+              ),
               sort_by: 'refresh_time',
               sort_order: 'asc',
             });
@@ -988,6 +1185,69 @@ const AccountsPage: React.FC = () => {
             <Input.TextArea rows={2} maxLength={200} showCount />
           </Form.Item>
         </Form>
+      </Modal>
+
+      <Modal
+        title="标签管理"
+        open={tagManagerOpen}
+        footer={null}
+        onCancel={() => setTagManagerOpen(false)}
+        width={520}
+      >
+        <Space direction="vertical" style={{ width: '100%' }} size={16}>
+          <Space size={4} wrap>
+            {tags.length ? (
+              tags.map((t) => (
+                <Popconfirm
+                  key={t.id}
+                  title={`确认删除标签「${t.name}」？将解除所有账号的关联。`}
+                  onConfirm={() => void onDeleteTag(t.id)}
+                >
+                  <Tag color={t.color} style={{ cursor: 'pointer' }}>
+                    {t.name} ×
+                  </Tag>
+                </Popconfirm>
+              ))
+            ) : (
+              <Typography.Text type="secondary">暂无标签</Typography.Text>
+            )}
+          </Space>
+          <Space.Compact style={{ width: '100%' }}>
+            <Input
+              placeholder="新标签名称"
+              value={newTagName}
+              maxLength={50}
+              onChange={(e) => setNewTagName(e.target.value)}
+              onPressEnter={() => void onCreateTag()}
+              style={{ width: '60%' }}
+            />
+            <input
+              type="color"
+              aria-label="标签颜色"
+              value={newTagColor}
+              onChange={(e) => setNewTagColor(e.target.value)}
+              style={{
+                width: 48,
+                height: 32,
+                border: '1px solid #d9d9d9',
+                borderRadius: 6,
+                background: '#fff',
+                padding: 2,
+                cursor: 'pointer',
+              }}
+            />
+            <Button
+              type="primary"
+              loading={tagCreating}
+              onClick={() => void onCreateTag()}
+            >
+              新建标签
+            </Button>
+          </Space.Compact>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            点击标签可删除；在账号列表通过「打标」为账号添加或移除标签。
+          </Typography.Text>
+        </Space>
       </Modal>
 
       <Modal

--- a/ant-design-pro/src/services/outlook/accounts.ts
+++ b/ant-design-pro/src/services/outlook/accounts.ts
@@ -46,6 +46,8 @@ export type AccountListParams = {
   sort_by?: 'refresh_time' | 'email';
   sort_order?: 'asc' | 'desc';
   tag_id?: number | number[];
+  /** 逗号分隔的标签 ID，与后端 /api/accounts 的 tag_ids 参数对应 */
+  tag_ids?: string;
 };
 
 export async function fetchAccounts(params: AccountListParams = {}) {

--- a/ant-design-pro/src/services/outlook/tags.test.ts
+++ b/ant-design-pro/src/services/outlook/tags.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  batchManageAccountTags,
+  createTag,
+  deleteTag,
+  fetchTags,
+  serializeTagIds,
+} from './tags';
+
+const requestMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./request', () => ({
+  outlookRequest: requestMock,
+}));
+
+describe('tags service (ZER-653)', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+    requestMock.mockResolvedValue({ success: true });
+  });
+
+  it('fetchTags 调用 GET /api/tags', async () => {
+    await fetchTags();
+    expect(requestMock).toHaveBeenCalledWith('/api/tags', { method: 'GET' });
+  });
+
+  it('createTag 提交名称与颜色', async () => {
+    await createTag('重点', '#ff4d4f');
+    expect(requestMock).toHaveBeenCalledWith('/api/tags', {
+      method: 'POST',
+      data: { name: '重点', color: '#ff4d4f' },
+    });
+  });
+
+  it('deleteTag 调用 DELETE /api/tags/:id', async () => {
+    await deleteTag(7);
+    expect(requestMock).toHaveBeenCalledWith('/api/tags/7', {
+      method: 'DELETE',
+    });
+  });
+
+  it('batchManageAccountTags 提交账号列表与动作', async () => {
+    await batchManageAccountTags([1, 2, 3], 5, 'add');
+    expect(requestMock).toHaveBeenCalledWith('/api/accounts/tags', {
+      method: 'POST',
+      data: { account_ids: [1, 2, 3], tag_id: 5, action: 'add' },
+    });
+  });
+
+  it('serializeTagIds 输出逗号分隔字符串，空输入返回 undefined', () => {
+    expect(serializeTagIds([1, 2, 3])).toBe('1,2,3');
+    expect(serializeTagIds([])).toBeUndefined();
+    expect(serializeTagIds(undefined)).toBeUndefined();
+  });
+});

--- a/ant-design-pro/src/services/outlook/tags.ts
+++ b/ant-design-pro/src/services/outlook/tags.ts
@@ -1,0 +1,58 @@
+import { outlookRequest } from './request';
+
+export type TagItem = {
+  id: number;
+  name: string;
+  color?: string;
+};
+
+export type TagsResponse = {
+  success: boolean;
+  tags: TagItem[];
+};
+
+/**
+ * 账号列表标签筛选参数：后端 /api/accounts 支持
+ * `tag_id`（可重复）或 `tag_ids`（逗号分隔），这里统一用逗号分隔形式。
+ */
+export function serializeTagIds(tagIds?: number[]): string | undefined {
+  if (!tagIds?.length) return undefined;
+  return tagIds.join(',');
+}
+
+export async function fetchTags() {
+  return outlookRequest<TagsResponse>('/api/tags', { method: 'GET' });
+}
+
+export async function createTag(name: string, color = '#1a1a1a') {
+  return outlookRequest<{
+    success: boolean;
+    tag?: TagItem;
+    message?: string;
+    error?: any;
+  }>('/api/tags', {
+    method: 'POST',
+    data: { name, color },
+  });
+}
+
+export async function deleteTag(tagId: number) {
+  return outlookRequest<{ success: boolean; message?: string; error?: any }>(
+    `/api/tags/${tagId}`,
+    { method: 'DELETE' },
+  );
+}
+
+export async function batchManageAccountTags(
+  accountIds: number[],
+  tagId: number,
+  action: 'add' | 'remove',
+) {
+  return outlookRequest<{ success: boolean; message?: string; error?: any }>(
+    '/api/accounts/tags',
+    {
+      method: 'POST',
+      data: { account_ids: accountIds, tag_id: tagId, action },
+    },
+  );
+}


### PR DESCRIPTION
## 问题（ZER-653）

后端已有 `/api/tags`（增删查）和 `/api/accounts/tags`（批量打标），账号列表接口已返回 `tags` 并支持 `tag_ids` 筛选，但新前端 `/accounts` 完全没有标签能力。

## 实现

- 新增 `services/outlook/tags.ts`：接入 `/api/tags` 与 `/api/accounts/tags`
- 账号列表新增标签列（彩色 chip 展示）
- 搜索表单按标签多选筛选（`tag_ids` 逗号分隔参数）
- 行内「打标」下拉：已有标签 ✓ 可移除，未有 + 可添加
- 批量工具栏：添加/移除标签
- 工具栏「标签管理」弹窗：新建（名称+颜色）、删除

## 验收对照

- [x] 账号列表展示账号标签
- [x] 可按标签筛选账号
- [x] 可为单个或多个账号添加、移除标签
- [x] 可新建和删除标签（后端无更新接口，编辑沿用 issue 允许的方案）
- [x] 标签名称和颜色直接使用后端数据

## 测试

- biome lint ✅ / tsc ✅ / vitest 106/106（含 5 项 tags service 单测）✅ / 生产构建 ✅

Closes ZER-653