### PR TITLE
chore(docker): .dockerignore 排除嵌套 node_modules/dist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,8 @@ ENV/
 
 # Node / Jest
 node_modules/
+**/node_modules/
+**/dist/
 tests/
 
 # 数据库文件（使用 volume 挂载）


### PR DESCRIPTION
## 问题\n\n`.dockerignore` 中 `node_modules/`、`dist/` 模式只匹配仓库根目录，不匹配 ``**/node_modules`` 这类嵌套路径。`ant-design-pro/node_modules`（约 1GB）被打进 Docker 构建上下文，导致：\n- 快照/镜像构建上下文上传慢且易超时失败（Daytona 快照构建多次因此失败）\n- 本地构建行为受工作区状态影响\n\n## 修复\n\n追加 `**/node_modules/` 与 `**/dist/` 两个模式，构建上下文从 ~1GB（10 万+文件）降至源码体积。前端仍在容器内由 Dockerfile 从源码构建，行为不变。\n\n## 验证\n\n- [x] `docker build` 语义不变（frontend 阶段自行 `npm install && npm run build`）