### PR TITLE
feat(zer-659): 系统设置 Telegram 增加「测试代理连通性」入口

### DIFF
--- a/ant-design-pro/src/pages/settings/index.tsx
+++ b/ant-design-pro/src/pages/settings/index.tsx
@@ -55,6 +55,8 @@ import {
   syncCfWorkerDomains,
   testEmailNotification,
   testTelegram,
+  testTelegramProxy,
+  type TelegramProxyTestResponse,
   testVerificationAi,
   testWebhook,
   triggerSystemUpdate,
@@ -147,6 +149,10 @@ const SettingsPage: React.FC = () => {
   const [webhookTestLoading, setWebhookTestLoading] = useState(false);
   const [webhookTestResult, setWebhookTestResult] =
     useState<WebhookTestResponse | null>(null);
+  const [telegramProxyTestLoading, setTelegramProxyTestLoading] =
+    useState(false);
+  const [telegramProxyTestResult, setTelegramProxyTestResult] =
+    useState<TelegramProxyTestResponse | null>(null);
 
   const settingsQuery = useQuery({
     queryKey: ['settings'],
@@ -517,6 +523,42 @@ const SettingsPage: React.FC = () => {
       message.error(pickSettingsError(normalized, 'Webhook 测试失败'));
     } finally {
       setWebhookTestLoading(false);
+    }
+  };
+
+  const testTelegramProxyUrl = async () => {
+    const proxyUrl = String(
+      form.getFieldValue('telegram_proxy_url') || '',
+    ).trim();
+    if (dirty) {
+      message.warning('请先保存当前 Telegram 配置，再测试代理连通性');
+      return;
+    }
+    setTelegramProxyTestLoading(true);
+    setTelegramProxyTestResult(null);
+    try {
+      const result = await testTelegramProxy(proxyUrl);
+      setTelegramProxyTestResult(result);
+      if (result?.success === false) {
+        message.error(pickSettingsError(result, '代理连通性测试失败'));
+      } else if (result?.ok === false) {
+        message.warning(result?.message || '代理可达但 Telegram 连接异常');
+      } else {
+        message.success(result?.message || '代理连通性测试成功');
+      }
+    } catch (error: any) {
+      const payload =
+        error?.data ||
+        error?.info ||
+        error?.response?.data || {
+          success: false,
+          message: error?.message || '代理连通性测试失败',
+          error,
+        };
+      setTelegramProxyTestResult(payload);
+      message.error(pickSettingsError(payload, '代理连通性测试失败'));
+    } finally {
+      setTelegramProxyTestLoading(false);
     }
   };
 
@@ -1040,16 +1082,80 @@ const SettingsPage: React.FC = () => {
                       style={{ width: '100%' }}
                     />
                   </Form.Item>
-                  <Form.Item name="telegram_proxy_url" label="代理 URL">
-                    <Input />
-                  </Form.Item>
-                  <Button
-                    onClick={() =>
-                      void runTest(testTelegram, 'Telegram 测试成功')
-                    }
+                  <Form.Item
+                    name="telegram_proxy_url"
+                    label="代理 URL"
+                    extra="留空则直连（用已保存配置）。格式：socks5://host:port 或 http://host:port"
                   >
-                    测试 Telegram
-                  </Button>
+                    <Input placeholder="socks5://user:pass@host:port 或 http://host:port" />
+                  </Form.Item>
+                  <Space wrap style={{ marginBottom: telegramProxyTestResult ? 16 : 0 }}>
+                    <Button
+                      onClick={() =>
+                        void runTest(testTelegram, 'Telegram 测试成功')
+                      }
+                    >
+                      测试 Telegram
+                    </Button>
+                    <Button
+                      loading={telegramProxyTestLoading}
+                      onClick={() => void testTelegramProxyUrl()}
+                    >
+                      测试代理连通性
+                    </Button>
+                  </Space>
+                  {telegramProxyTestResult && (
+                    <Alert
+                      showIcon
+                      style={{ marginBottom: 16 }}
+                      type={
+                        telegramProxyTestResult.success &&
+                        telegramProxyTestResult.ok !== false
+                          ? 'success'
+                          : 'error'
+                      }
+                      message={
+                        telegramProxyTestResult.success &&
+                        telegramProxyTestResult.ok !== false
+                          ? '代理连通性测试完成'
+                          : pickSettingsError(
+                              { error: telegramProxyTestResult.error },
+                              telegramProxyTestResult.message ||
+                                '代理连通性测试失败',
+                            )
+                      }
+                      description={
+                        <Space direction="vertical" size={2}>
+                          <Typography.Text>
+                            状态：
+                            {telegramProxyTestResult.ok === false
+                              ? `代理可达但 Telegram 返回异常（网络不可用/被拦截）`
+                              : telegramProxyTestResult.success
+                                ? '代理连通成功'
+                                : '代理连接失败'}
+                          </Typography.Text>
+                          {telegramProxyTestResult.message && (
+                            <Typography.Text>
+                              服务端返回：
+                              {telegramProxyTestResult.message}
+                            </Typography.Text>
+                          )}
+                          {telegramProxyTestResult.latency_ms != null && (
+                            <Typography.Text>
+                              耗时：
+                              {telegramProxyTestResult.latency_ms} ms
+                            </Typography.Text>
+                          )}
+                          {telegramProxyTestResult.error?.code && (
+                            <Typography.Text>
+                              错误码：
+                              {String(telegramProxyTestResult.error.code)}
+                            </Typography.Text>
+                          )}
+                        </Space>
+                      }
+                    />
+                  )}
                 </ProCard>
               ),
             },

--- a/ant-design-pro/src/services/outlook/settings.ts
+++ b/ant-design-pro/src/services/outlook/settings.ts
@@ -56,6 +56,24 @@ export async function testTelegram() {
   );
 }
 
+export type TelegramProxyTestResponse = {
+  success: boolean;
+  ok?: boolean;
+  message?: string;
+  message_en?: string;
+  latency_ms?: number;
+  proxy_url?: string;
+  error?: any;
+};
+
+/** 测试 Telegram 代理连通性：后端会用表单里的代理地址实际请求 api.telegram.org/getMe。 */
+export async function testTelegramProxy(proxyUrl: string) {
+  return outlookRequest<TelegramProxyTestResponse>(
+    '/api/settings/test-telegram-proxy',
+    { method: 'POST', data: { proxy_url: proxyUrl }, skipErrorHandler: true },
+  );
+}
+
 export async function testEmailNotification() {
   return outlookRequest<{ success: boolean; message?: string; error?: any }>(
     '/api/settings/email-test',


### PR DESCRIPTION
## 背景

新旧前端对照时,旧站系统设置 → 自动化 → Telegram 支持「测试连通性」(用代理实际请求 api.telegram.org/getMe)。新前端 `/settings` → 通知 已有 Telegram 配置表单(Bot Token / Chat ID / 轮询间隔 / 代理 URL / 测试 Telegram),但缺代理连通性测试入口。后端接口 `POST /api/settings/test-telegram-proxy` 已存在,前端未接入。

## 改动

- `services/outlook/settings.ts` 新增 `testTelegramProxy(proxyUrl)` 与 `TelegramProxyTestResponse` 类型
- 通知 Tab Telegram 区块新增「测试代理连通性」按钮,调用后端 getMe 探测
- 测试前要求先保存(与 Webhook 测试行为一致),避免用未保存的表单值误导
- 成功/失败/耗时/错误码以 Alert 展示
- 代理 URL 输入框补充格式提示

## 验证

- 本地: biome lint ✅ / tsc ✅ / vitest 110/110 ✅ / 生产构建 ✅
- CI: 待 PR 触发

Refs ZER-659