### PR TITLE
chore(release): prepare v2.9.10 dual-frontend release (SPA + legacy images, docs)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,6 +16,7 @@ on:
       - 'pyproject.toml'
       - 'requirements.txt'
       - 'Dockerfile'
+      - 'Dockerfile.legacy'
       - 'templates/**'
       - 'static/**'
       - 'ant-design-pro/**'
@@ -127,6 +128,78 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Image digest
+        run: echo ${{ steps.build.outputs.digest }}
+
+  # 旧前端（Legacy）镜像：Dockerfile.legacy 构建，tag 统一带 -legacy 后缀
+  build-and-push-legacy:
+    needs: quality-gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image names
+        id: names
+        shell: bash
+        run: |
+          # GHCR 要求小写
+          echo "ghcr_image=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outlook-email-plus-legacy" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            echo "dockerhub_enabled=true" >> "$GITHUB_OUTPUT"
+            echo "images=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outlook-email-plus-legacy,${{ env.DOCKERHUB_IMAGE }}-legacy" >> "$GITHUB_OUTPUT"
+          else
+            echo "dockerhub_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "images=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outlook-email-plus-legacy" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub (optional)
+        if: steps.names.outputs.dockerhub_enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.names.outputs.images }}
+          tags: |
+            type=ref,event=branch,suffix=-legacy
+            type=ref,event=tag,suffix=-legacy
+            type=sha,prefix={{branch}}-,suffix=-legacy,enable=${{ startsWith(github.ref, 'refs/heads/') }}
+            type=sha,prefix={{tag}}-,suffix=-legacy,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest-legacy,enable=${{ github.ref_name == 'main' || github.ref_name == 'master' }}
+
+      - name: Build and push legacy Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.legacy
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to OutlookMail Plus are documented in this file.
 
-## [Unreleased]
+## [v2.9.10] - 2026-08-17
 
 ### 优化 / Improvements
 
 - **ZER-657 新前端临时邮箱设置迁移补齐**：临时邮箱页的设置入口直达独立设置页签；恢复 Provider、API、域名、默认域名、前缀规则和 Cloudflare Worker 配置，并补充 JSON 结构校验、脱敏密钥保护与域名对象展示兼容。
 - **ZER-582 纯白前端服务展示优化**：保持现有纯白主题、导航与全局色板不变；API Key 改为名称 / 状态 / 脱敏 Token / 操作的简洁列表，权限和邮箱范围固定在创建时选择并通过详情查看；Webhook 测试展示已保存配置的真实投递 URL、上游 HTTP 状态、耗时和尝试次数，Token 留空表示清空；AI 测试区分连通性与契约状态，并在请求失败时保留端点、模型和 HTTP 诊断。
 - **版本号更新为 2.9.10**。
+- **双镜像发布**：仓库提供两套 Dockerfile —— `Dockerfile`（默认，新前端 Ant Design Pro SPA）与 `Dockerfile.legacy`（旧前端）。Tag 发布时 CI 同时构建并推送两个镜像：`outlook-email-plus:v2.9.10`（SPA）与 `outlook-email-plus-legacy:v2.9.10-legacy`，部署时按前端模式选择镜像。
 
 ### 集成 / Integration
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 # syntax=docker/dockerfile:1
+#
+# 默认镜像（新前端 SPA 模式）
+# =====================================================================
+# 本文件构建「新前端」版本：先构建 ant-design-pro（Ant Design Pro + Umi Max）
+# 静态产物，再与 Flask 后端一起打包，SPA_ENABLED=true 由 Flask 直接托管前端。
+# 如需「旧前端」镜像（无 Node 构建、templates/static 旧界面），使用：
+#   docker build -f Dockerfile.legacy -t outlook-email-plus-legacy .
+# =====================================================================
 
 FROM node:22-bookworm-slim AS frontend
 WORKDIR /frontend

--- a/Dockerfile.legacy
+++ b/Dockerfile.legacy
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+#
+# Legacy 镜像（旧前端模式）
+# =====================================================================
+# 本文件构建「旧前端」版本：仅打包 Flask 后端与 templates/static 旧界面，
+# 不构建 ant-design-pro 新前端（SPA）。适用于：
+#   - 需要旧前端界面 / 低资源部署（无需 Node 构建，镜像更小）
+#   - 新前端出现问题时快速回滚到旧 UI
+# 对应镜像 tag 统一带 `-legacy` 后缀：
+#   ghcr.io/zeropointsix/outlook-email-plus:latest-legacy
+#   ghcr.io/zeropointsix/outlook-email-plus:vX.Y.Z-legacy
+# 详见 RELEASE.md「双镜像发布」与 README「两种前端模式」。
+# =====================================================================
+
+# 使用 Python 3.11 作为基础镜像
+FROM python:3.11-slim
+
+# 设置工作目录
+WORKDIR /app
+
+# 设置环境变量（SPA_ENABLED=false：禁止服务任何 SPA 产物，固定旧前端）
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    GUNICORN_WORKERS=1 \
+    GUNICORN_THREADS=8 \
+    GUNICORN_TIMEOUT=120 \
+    SPA_ENABLED=false
+
+# 复制依赖文件
+COPY requirements.txt .
+
+# 安装依赖（pip 走国内镜像加速）
+RUN pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip install gunicorn -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+# 复制应用代码（.dockerignore 已排除 node_modules/** 与 **/dist/）
+COPY . .
+
+# 创建数据目录
+RUN mkdir -p /app/data && chmod +x /app/scripts/start-gunicorn.sh
+
+# 暴露端口
+EXPOSE 5000
+
+# 健康检查
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s CMD ["python","-c","import urllib.request as u; u.urlopen('http://localhost:5000/healthz', timeout=4).read()"]
+
+# 启动应用：默认单 worker + 多线程，避免同步长轮询阻塞整站
+CMD ["scripts/start-gunicorn.sh"]

--- a/README.en.md
+++ b/README.en.md
@@ -36,7 +36,7 @@ The repository already includes some screenshots, and more can be added later.
 
 ## Version Highlights
 
-Current stable version: `v2.2.2`
+Current stable version: `v2.9.10`
 
 ### Recent Version Overview
 
@@ -126,6 +126,15 @@ web_outlook_app.py    Backward-compatible entrypoint
 ## Quick Start
 
 ### Docker Deployment
+
+**Two frontend modes**: the default image ships the *new frontend* (Ant Design Pro SPA, default since v2.9.10). To use the *legacy frontend* (lighter, no Node build step), use the `-legacy` image:
+
+| Mode | GHCR | Docker Hub |
+|------|------|------------|
+| New frontend (default) | `ghcr.io/zeropointsix/outlook-email-plus:v2.9.10` | `guangshanshui/outlook-email-plus:v2.9.10` |
+| Legacy frontend | `ghcr.io/zeropointsix/outlook-email-plus-legacy:v2.9.10-legacy` | `guangshanshui/outlook-email-plus-legacy:v2.9.10-legacy` |
+
+`latest` / `latest-legacy` tags track the main branch. To roll back to the legacy UI, set `IMAGE_TAG` to `v2.9.10-legacy`. Both images share the same backend API and database.
 
 **Option 1: docker run (quick start)**
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OutlookMail Plus 是一款面向个人与团队的注册邮箱管理器。
 
 ## 版本亮点
 
-当前稳定版本：`v2.2.2`
+当前稳定版本：`v2.9.10`
 
 ### 近期版本速览
 
@@ -131,6 +131,15 @@ web_outlook_app.py    兼容入口
 ## 快速开始
 
 ### Docker 部署
+
+**两种前端模式**：镜像默认是「新前端」（Ant Design Pro SPA，从 v2.9.10 起为默认）。如需旧前端界面（更轻量、无 Node 构建），使用 `-legacy` 镜像：
+
+| 模式 | GHCR | Docker Hub |
+|------|------|------------|
+| 新前端（默认） | `ghcr.io/zeropointsix/outlook-email-plus:v2.9.10` | `guangshanshui/outlook-email-plus:v2.9.10` |
+| 旧前端 legacy | `ghcr.io/zeropointsix/outlook-email-plus-legacy:v2.9.10-legacy` | `guangshanshui/outlook-email-plus-legacy:v2.9.10-legacy` |
+
+对应 `latest` / `latest-legacy` 标签分别跟随 main 分支自动更新；新前端回滚旧界面时，把 `IMAGE_TAG` 切到 `v2.9.10-legacy`（或更低版本即可）。两种镜像共用同一后端 API 与数据库。
 
 **方式一：docker run（快速体验）**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,10 @@
 
 - **代码版本**：以 Git Tag 为准，格式 `vX.Y.Z`（例如 `v1.11.0`）
 - **发布说明**：`CHANGELOG.md` 中对应版本段落（`## [vX.Y.Z] - YYYY-MM-DD`）
-- **Docker 镜像**：
-  - DockerHub：`guangshanshui/outlook-email-plus`（常用：`latest` / `vX.Y.Z`）
-  - GHCR：`ghcr.io/zeropointsix/outlook-email-plus`（常用：`latest` / `main` / `vX.Y.Z`）
+- **Docker 镜像（双镜像，两套前端）**：
+  - 新前端 SPA（默认）：DockerHub `guangshanshui/outlook-email-plus`；GHCR `ghcr.io/zeropointsix/outlook-email-plus`（标签：`latest` / `main` / `vX.Y.Z`）
+  - 旧前端 Legacy：DockerHub `guangshanshui/outlook-email-plus-legacy`；GHCR `ghcr.io/zeropointsix/outlook-email-plus-legacy`（标签：`latest-legacy` / `main-legacy` / `vX.Y.Z-legacy`）
+  - 双镜像分别由 `Dockerfile`（新前端 SPA）与 `Dockerfile.legacy`（旧前端）构建
 
 > 说明：镜像以 GitHub Actions 工作流 `.github/workflows/docker-build-push.yml` 为准。
 
@@ -28,10 +29,11 @@ Tag 统一带 `v` 前缀：`v1.11.0`。
 仓库存在工作流：**Build and Push Docker Image**（`docker-build-push.yml`），触发规则：
 - **push 到 `main/master/dev`**：会构建并推送镜像（其中 `main/master` 会推 `latest`）
 - **push Tag `v*.*.*`**：会构建并推送以 Tag 命名的镜像（例如 `v1.11.0`）
+- **双镜像**：打 Tag 或推 main/dev 时，CI 会同时构建两套前端镜像 —— 新前端 SPA（`vX.Y.Z` / `latest` 等）与旧前端 Legacy（`vX.Y.Z-legacy` / `latest-legacy` 等）
 
 因此：
-- 想要“稳定版本镜像”（`vX.Y.Z`）→ **必须打 Tag 并 push Tag**
-- 想要“体验最新代码”（`latest`）→ **push 到 main/master 即可**
+- 想要“稳定版本镜像”（`vX.Y.Z` / `vX.Y.Z-legacy`）→ **必须打 Tag 并 push Tag**
+- 想要“体验最新代码”（`latest` / `latest-legacy`）→ **push 到 main/master 即可**
 
 ## 发布前检查（Release 前置门禁）
 
@@ -121,11 +123,14 @@ git push origin vX.Y.Z
 6. **验证镜像**
 
 ```bash
-# 验证稳定版本镜像
+# 验证稳定版本镜像（新前端 SPA）
 docker pull guangshanshui/outlook-email-plus:vX.Y.Z
+# 验证稳定版本镜像（旧前端 legacy）
+docker pull guangshanshui/outlook-email-plus-legacy:vX.Y.Z-legacy
 
 # 验证 latest（main/master）
 docker pull guangshanshui/outlook-email-plus:latest
+docker pull guangshanshui/outlook-email-plus-legacy:latest-legacy
 ```
 
 验证点：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,24 @@ services:
   app:
     # 模式一（默认）：直接拉取远端镜像（适合大多数用户）
     # 镜像标签可通过 .env 的 IMAGE_TAG 控制（默认 latest）
-    # GHCR 镜像（国内网络推荐，访问更稳定）：
+    # ---------- 新前端（Ant Design Pro SPA，默认） ----------
     image: ghcr.io/zeropointsix/outlook-email-plus:${IMAGE_TAG:-latest}
-    # Docker Hub 镜像（如需切换取消注释，并注释上行）：
+    # Docker Hub 备选：
     # image: guangshanshui/outlook-email-plus:${IMAGE_TAG:-latest}
+    # ---------- 旧前端（legacy，需旧界面时切换） ----------
+    # 固定版本示例：IMAGE_TAG=v2.9.10-legacy
+    # image: ghcr.io/zeropointsix/outlook-email-plus-legacy:${IMAGE_TAG:-latest-legacy}
+    # image: guangshanshui/outlook-email-plus-legacy:${IMAGE_TAG:-latest-legacy}
 
     # 模式二（开发者）：本地构建（取消注释 build，并按需注释 image）
+    # 新前端：
     # build:
     #   context: .
     #   dockerfile: Dockerfile
+    # 旧前端：
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.legacy
 
     container_name: outlook-email-plus
 


### PR DESCRIPTION
## 背景

v2.9.10 是新前端（Ant Design Pro SPA，PR #109）合入 main 后的首个正式发版。用户要求按发版流程执行，并准备两套 Dockerfile 以分别启动新/旧前端。

## 改动

1. **双 Dockerfile**
   - `Dockerfile`（默认）：新前端 SPA 镜像（Node 构建 ant-design-pro + Flask 后端，SPA_ENABLED=true）
   - `Dockerfile.legacy`（新增）：旧前端镜像（纯 Python，无 Node 构建，SPA_ENABLED=false），适用于旧界面部署与快速回滚
2. **CI 双镜像发布**（`.github/workflows/docker-build-push.yml`）
   - 新增 `build-and-push-legacy` job，依赖同一 quality-gate
   - Tag 构建：`outlook-email-plus:v2.9.10`（SPA）+ `outlook-email-plus-legacy:v2.9.10-legacy`；main 推送：`latest` + `latest-legacy`
   - paths 增加 `Dockerfile.legacy` 触发
3. **文档更新**
   - `CHANGELOG.md`：`[Unreleased]` → `## [v2.9.10] - 2026-08-17`，新增「双镜像发布」条目
   - `RELEASE.md`：术语、自动化发布机制、验证镜像步骤更新为双镜像说明
   - `README.md` / `README.en.md`：稳定版本改为 v2.9.10，Docker 部署新增「两种前端模式」对照表
   - `docker-compose.yml`：新增 legacy 镜像 / Dockerfile.legacy 构建注释示例

## 验证

- `__version__` = 2.9.10 与 CHANGELOG `## [v2.9.10]` 对齐
- `tests.test_release_version_gate` 5/5 通过
- workflow YAML 语法校验通过
- 合并后将打 tag `v2.9.10`，由 CI 自动完成双镜像发布与 GitHub Release

Refs ZER-733